### PR TITLE
Use Ebib databases if present

### DIFF
--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -332,7 +332,7 @@ ENTRY."
    with width = (with-helm-window (helm-bibtex-window-width))
    for entry in candidates
    for entry = (cdr entry)
-   for entry-key = (helm-bibtex-get-value entry "=key=") 
+   for entry-key = (helm-bibtex-get-value entry "=key=")
    for fields = (--map (helm-bibtex-clean-string
                         (helm-bibtex-get-value entry it " "))
                        '("author" "title" "year" "=has-pdf=" "=has-note=" "=type="))
@@ -525,7 +525,7 @@ defined.  Surrounding curly braces are stripped."
   (let ((browse-url-browser-function
           (or helm-bibtex-browser-function
               browse-url-browser-function)))
-    (cond 
+    (cond
       ((stringp url-or-function)
         (helm-browse-url (format url-or-function (url-hexify-string helm-pattern))))
       ((functionp url-or-function)
@@ -550,7 +550,7 @@ entry for each BibTeX file that will open that file for editing."
   (let ((bib-files (if (listp helm-bibtex-bibliography)
                        helm-bibtex-bibliography
                      (list helm-bibtex-bibliography))))
-    (-concat 
+    (-concat
       (--map (cons (s-concat "Create new entry in " (f-filename it))
                    `(lambda () (find-file ,it) (goto-char (point-max))))
              bib-files)

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -274,7 +274,7 @@ is the entry (only the fields listed above) as an alist."
   "Given a BibTeX key this function scans all bibliographies
 listed in `helm-bibtex-bibliography' and returns an alist of the
 record with that key."
-  (let* ((sources (helm-bibtex-split-library)))
+  (let* ((sources (helm-bibtex-split-bibliography)))
     (or (cl-loop for db in (cadr sources)
                  for entry = (ebib-db-get-entry entry-key db 'noerror)
                  thereis entry)

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -220,7 +220,7 @@ title, year, BibTeX key, and entry type."
 actually exist."
   (mapc (lambda (file)
           (unless (f-exists? file)
-                  (user-error "BibTeX file %s could not be found." file)))
+            (user-error "BibTeX file %s could not be found." file)))
         (if (listp helm-bibtex-bibliography)
             helm-bibtex-bibliography
           (list helm-bibtex-bibliography))))

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -291,7 +291,7 @@ record with that key."
 (defun helm-bibtex-prep-entry (entry &optional fields)
   "Prep ENTRY for display.
 ENTRY is an alist representing an entry as returned by
-parsebib-read-entry. All the fields not in FIELDS are removed
+`parsebib-read-entry'. All the fields not in FIELDS are removed
 from ENTRY, with the exception of the \"=type=\" and \"=key=\"
 fields, which are always kept. If FIELDS is empty, all fields are
 kept. Also add a pdf and/or notes symbol, if they exist for


### PR DESCRIPTION
Hi Titus,

I decided to see if consulting Ebib databases from `helm-bibtex` makes much of a difference. The results are, well, mixed. On my main laptop, which is a decent enough box with a Core i5 CPU and 8MB of memory, the difference is benchmarkable but not noticeable. With my main `.bib` file (about 1100 entries), `helm-bibtex-candidates` takes about twice as long if the entries are read from disk compared to when they are taken from an Ebib database. But execution time runs in the 1.0e-5 to 1.0e-6 seconds range, so if you’re not timing it, you can’t tell the difference. On my Atom-based netbook, the difference is again a factor of two and it is noticeable if you pay attention, but not to the extent that going through Ebib feels like a real improvement. The difference is less than a second.

So although I don’t have a larger database to test with, I think it’s safe to say that few users will really notice the difference. I suspect that even with a `.bib` file of 10,000 entries you wouldn't notice anything on a modern machine.

I’m offering the code anyway, so you can check it out and decide for yourself. Personally, I’m not convinced it’s worth complicating the code for, though.

J.
