### PR TITLE
fix bug where the wrong key is found in helm-bibtex-show-entry

### DIFF
--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -268,7 +268,7 @@ containing authors, editors, title, year, type, and key of the
 entry.  This is string is used for matching.  The second element
 is the entry (only the fields listed above) as an alist."
   ;; Open configured bibliographies in temporary buffer:
-  (with-temp-buffer 
+  (with-temp-buffer
     (mapc #'insert-file-contents
           (if (listp helm-bibtex-bibliography)
               helm-bibtex-bibliography
@@ -292,7 +292,7 @@ is the entry (only the fields listed above) as an alist."
 (defun helm-bibtex-resolve-crossrefs (entries)
   "Expand all entries with fields from cross-references entries."
    (cl-loop
-    with entry-hash = 
+    with entry-hash =
       (cl-loop
        with ht = (make-hash-table :test #'equal :size (length entries))
        for entry in entries
@@ -335,7 +335,7 @@ appended to the requested entry."
 
 (defun helm-bibtex-get-entry1 (entry-key)
   (with-temp-buffer
-    (mapc #'insert-file-contents 
+    (mapc #'insert-file-contents
           (if (listp helm-bibtex-bibliography)
               helm-bibtex-bibliography
             (list helm-bibtex-bibliography)))
@@ -710,14 +710,16 @@ defined.  Surrounding curly braces are stripped."
     (dolist (bibtex-file (if (listp helm-bibtex-bibliography)
                              helm-bibtex-bibliography
                            (list helm-bibtex-bibliography)))
-      (let ((buf (helm-bibtex-buffer-visiting bibtex-file)))
+      (let ((buf (helm-bibtex-buffer-visiting bibtex-file))
+            (entries '()))
         (find-file bibtex-file)
-        (goto-char (point-min))
-        (if (re-search-forward
-             (concat "^@\\(" parsebib--bibtex-identifier
-                     "\\)[[:space:]]*[\(\{][[:space:]]*"
-                     (regexp-quote key) "[[:space:]]*,") nil t)
-            (throw 'break t)
+        (bibtex-map-entries
+         (lambda (key start end)
+           (add-to-list 'entries (cons key start))))
+        (if (assoc key entries)
+            (progn
+              (goto-char (cdr (assoc key entries)))
+              (throw 'break t))
           (unless buf
             (kill-buffer)))))))
 
@@ -725,7 +727,7 @@ defined.  Surrounding curly braces are stripped."
   (let ((browse-url-browser-function
           (or helm-bibtex-browser-function
               browse-url-browser-function)))
-    (cond 
+    (cond
       ((stringp url-or-function)
         (helm-browse-url (format url-or-function (url-hexify-string helm-pattern))))
       ((functionp url-or-function)
@@ -750,7 +752,7 @@ entry for each BibTeX file that will open that file for editing."
   (let ((bib-files (if (listp helm-bibtex-bibliography)
                        helm-bibtex-bibliography
                      (list helm-bibtex-bibliography))))
-    (-concat 
+    (-concat
       (--map (cons (s-concat "Create new entry in " (f-filename it))
                    `(lambda () (find-file ,it) (goto-char (point-max))))
              bib-files)


### PR DESCRIPTION
If you have two entries, in this order, this function had a bug if you try to find the second key. The search would stop on the first key because it matches. This fix avoids that by not using a search, but getting all the keys and looking up the location.

@article{boes-2015-estim-bulk-si,
  author =	 {Jacob R. Boes and Gamze Gumuslu and James B. Miller and Andrew
                  J. Gellman and John R. Kitchin},
  title =	 {Supporting Information: Estimating Bulk-Composition-Dependent
                  \ce{H2} Adsorption Energies on \ce{Cu_{x}Pd_{1-x}} Alloy (111)
                  Surfaces},
  keywords =	 {orgmode},
  journal =	 {ACS Catalysis},
  volume =	 {5},
  pages =	 {1020-1026},
  year =	 2015,
  doi =		 {10.1021/cs501585k},
  url =		 {http://pubs.acs.org/doi/suppl/10.1021/cs501585k/suppl_file/cs501585k_si_001.pdf},
}

@article{boes-2015-estim-bulk,
  author =	 {Jacob R. Boes and Gamze Gumuslu and James B. Miller and Andrew
                  J. Gellman and John R. Kitchin},
  title =	 {Estimating Bulk-Composition-Dependent \ce{H2} Adsorption
                  Energies on \ce{Cu_{x}Pd_{1-x}} Alloy (111) Surfaces},
  journal =	 {ACS Catalysis},
  keywords =	 {orgmode},
  volume =	 5,
  pages =	 {1020-1026},
  year =	 2015,
  doi =		 {10.1021/cs501585k},
  url =		 {http://dx.doi.org/10.1021/cs501585k},
}