### PR TITLE
quick fixes for compatibility and search problem

### DIFF
--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -711,11 +711,9 @@ defined.  Surrounding curly braces are stripped."
     ;; from the template:
     (find-file helm-bibtex-notes-path)
     (goto-char (point-min))
-    (if (re-search-forward (concat "\\b" key "\\b") nil t)
+    (if (or (search-forward (concat ":BIBTEX-KEY: " key) nil t) (search-forward (concat "* " key) nil t))
         (when (eq major-mode 'org-mode)
-          (outline-hide-other)
-          (outline-show-subtree)
-          (outline-previous-visible-heading 1)
+          (org-show-context)
           (recenter-top-bottom 1))
       (goto-char (point-max))
       (insert (s-format helm-bibtex-notes-template


### PR DESCRIPTION
Line 714: The idea here is to only catch keys if they are a `:BIBTEX-KEY:` property or at the start of an org-mode headline. Someone familiar with using regexps in org-mode could do this much better.

Lines 716-718: I don't see `outline-hide-other` and `outline-show-subtree` defined in Emacs 24.3.1. I'm not sure if my change will behave differently, but it seems OK so far.