### PR TITLE
Fix for searching higher level notes

### DIFF
--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -873,10 +873,12 @@ defined.  Surrounding curly braces are stripped."
     (if (re-search-forward (format helm-bibtex-notes-key-pattern key) nil t)
                                         ; Existing entry found:
         (when (eq major-mode 'org-mode)
-          (outline-previous-visible-heading 1)
           (org-narrow-to-subtree)
-          (org-show-subtree)
-          (org-cycle-hide-drawers nil))
+          (save-restriction
+            (outline-previous-visible-heading 1)
+            (org-narrow-to-subtree)
+            (org-show-subtree)
+            (org-cycle-hide-drawers nil)))
                                         ; Create a new entry:
       (let ((entry (helm-bibtex-get-entry key)))
         (goto-char (point-max))


### PR DESCRIPTION
My notes use level 2 headings. If you follow the structure below, try opening notes for Author 1 and let me know if you see the problem.

```
* Topic 1
** Author 1 (1999) Title
   :PROPERTIES:
   :Custom_ID: Key1
   :END:
* COMMENT
** Author 2 (2000) Title
   :PROPERTIES:
   :Custom_ID: Key2
   :END:

```