### PR TITLE
require helm-config

### DIFF
--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -84,6 +84,7 @@
 ;;; Code:
 
 (require 'helm)
+(require 'helm-config)
 (require 'helm-net)
 (require 'helm-plugin)
 (require 'parsebib)


### PR DESCRIPTION
The keymap isn't setup for helm without helm-config.  easy-menu-add-item
errors out because it can't find the keymap.

Fixes #49.