### PR TITLE
ivy-bibtex: Add heuristic transformer

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -295,15 +295,31 @@ before being saved."
                (entries (bibtex-completion-prepare-entries entries))
                (entries (nreverse entries))
                (entries
-                (--map (cons (bibtex-completion-clean-string
-                                  (s-join " " (-map #'cdr it))) it)
-                           entries)))
+                (mapcar #'bibtex-completion-add-candidate-string
+                        entries)))
           (setq bibtex-completion-cached-candidates
                 (if (functionp formatter)
                     (funcall formatter entries)
                   entries)))
         (setq bibtex-completion-bibliography-hash bibliography-hash))
       bibtex-completion-cached-candidates)))
+
+(defun bibtex-completion-add-candidate-string (entry)
+  "Add string describing candidate to head of ENTRY. This string
+is specially formatted for `ivy-bibtex-display-transformer'."
+  (cons
+   (mapconcat
+    (lambda (field)
+      (let ((res (bibtex-completion-clean-string
+                  (bibtex-completion-get-value field entry " "))))
+        (if (member field '("author" "editor"))
+            (bibtex-completion-shorten-authors res)
+          res)))
+    (if (assoc-string "author" entry 'case-fold)
+        '("author" "title" "year" "=has-pdf=" "=has-note=" "=type=")
+      '("editor" "title" "year" "=has-pdf=" "=has-note=" "=type="))
+    "\t")
+   entry))
 
 (defun bibtex-completion-resolve-crossrefs (entries)
   "Expand all entries with fields from cross-references entries."


### PR DESCRIPTION
Here's a different approach to the formatting. The idea is to use a percentage of the available width for authors, fixed sizes for year and type, and the remaining width for the title. 

The pre-process thing is a hack right now. If you like this I can make this string the default so the transformer works agnostically. 