### PR TITLE
make ivy-bibtex default action easily customizable

### DIFF
--- a/README.org
+++ b/README.org
@@ -273,22 +273,10 @@ The second argument of ~helm-add-action-to-source~ is the function that executes
 
 The function ~helm-add-action-to-source~ can also be used to add new actions to helm-bibtex.
 
-*Ivy-bibtex*: To change the default action, the command ~ivy-bibtex~ needs to be redefined.  Specifically, we have to specify the default action in the :action slot of the function ivy-read.  For example, to change the default action to /insert BibTeX key/, use the following definition:
+*Ivy-bibtex*: The default action can be changed by customizing the variable ~ivy-bibtex-default-action~. For example, to change the default action to /insert BibTeX key/, use the following:
 
 #+BEGIN_SRC emacs-lisp
-(defun ivy-bibtex (&optional arg)
-  "Search BibTeX entries using ivy.
-
-With a prefix ARG the cache is invalidated and the bibliography
-reread."
-  (interactive "P")
-  (when arg
-    (setq bibtex-completion-bibliography-hash ""))
-  (bibtex-completion-init)
-  (ivy-read "BibTeX Items: "
-            (bibtex-completion-candidates 'ivy-bibtex-candidates-formatter)
-            :caller 'ivy-bibtex
-            :action 'bibtex-completion-insert-key))
+(setq ivy-bibtex-default-action 'bibtex-completion-insert-key)
 #+END_SRC
 
 ** Window size

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -123,7 +123,7 @@
 (defcustom helm-bibtex-full-frame t
   "Non-nil means open `helm-bibtex' using the entire window. When
 nil, the window will split below."
-  :group 'helm-bibtex
+  :group 'bibtex-completion
   :type 'boolean)
 
 (easy-menu-add-item nil '("Tools" "Helm" "Tools") ["BibTeX" helm-bibtex t])

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -72,6 +72,11 @@
 (require 'ivy)
 (require 'bibtex-completion)
 
+(defcustom ivy-bibtex-default-action 'bibtex-completion-open-pdf
+  "The default action for the `ivy-bibtex` command."
+  :group 'bibtex-completion
+  :type 'function)
+  
 (defun ivy-bibtex-candidates-formatter (candidates)
   (let ((width (frame-width)))
     (bibtex-completion-candidates-formatter candidates width)))
@@ -89,7 +94,7 @@ reread."
   (ivy-read "BibTeX Items: "
             (bibtex-completion-candidates 'ivy-bibtex-candidates-formatter)
             :caller 'ivy-bibtex
-            :action 'bibtex-completion-open-pdf))
+            :action ivy-bibtex-default-action))
 
 (ivy-set-actions
  'ivy-bibtex


### PR DESCRIPTION
- Added a custom variable ivy-bibtex-default-action, so that the ivy-bibtex default action can be changed without redefining the whole ivy-bibtex-function.
- Updated the readme acordingly.
- Also fixed a typo (I think) in helm-bibtex.el.