### PR TITLE
add fallback options to ivy-bibtex

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,6 +9,7 @@ Helm-bibtex and ivy-bibtex allow you to search and manage your BibTeX bibliograp
 Ivy-bibtex is experimental at this time, lacks some features, and may be noticeably slower than helm-bibtex when used with larger bibliographies.
 
 * News
+- [2016-09-20 Tue] :: Added fallback options to ivy frontend.
 - [2016-04-18 Moi] :: Improved support for Mendely/Jabref/Zotero way of referencing PDFs.
 - [2016-04-12 Wed] :: Added ivy front-end.
 - [2016-04-06 Wed] :: Generic functions are factored out into a backend for use with other completion frameworks like ivy.

--- a/README.org
+++ b/README.org
@@ -225,7 +225,7 @@ See also the section [[https://github.com/tmalsburg/helm-bibtex#insertion-of-lat
 
 ** Online databases
 
-Online databases can be configured using the customization variable ~bibtex-completion-fallback-options~.  This variable contains an alist where the first element of each entry is the name of the database and the second element is either a URL or a function.  The URL must contain a ~%s~ at the position where the current search expression should be inserted.  If a function is used, that function should not take any arguments.
+Online databases can be configured using the customization variable ~bibtex-completion-fallback-options~.  This variable contains an alist where the first element of each entry is the name of the database and the second element is either a URL or a function.  The URL must contain a ~%s~ at the position where the current search expression should be inserted.  If a function is used, that function should take this search expression as single argument.
 
 ** Key-bindings
 

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -135,13 +135,13 @@ should be a single character."
 
 (defcustom bibtex-completion-fallback-options
   '(("CrossRef                                  (biblio.el)"
-     . (lambda (string) (biblio-lookup #'biblio-crossref-backend string)))
+     . (lambda (search-expression) (biblio-lookup #'biblio-crossref-backend search-expression)))
     ("arXiv                                     (biblio.el)"
-     . (lambda (string) (biblio-lookup #'biblio-arxiv-backend string)))
+     . (lambda (search-expression) (biblio-lookup #'biblio-arxiv-backend search-expression)))
     ("DBLP (computer science bibliography)      (biblio.el)"
-     . (lambda (string) (biblio--lookup-1 #'biblio-dblp-backend string)))
+     . (lambda (search-expression) (biblio--lookup-1 #'biblio-dblp-backend search-expression)))
     ("HAL (French open archive)                 (biblio.el)"
-     . (lambda (string) (biblio--lookup-1 #'biblio-hal-backend string)))
+     . (lambda (search-expression) (biblio--lookup-1 #'biblio-hal-backend search-expression)))
     ("Google Scholar                            (web)"
      . "https://scholar.google.co.uk/scholar?q=%s")
     ("Pubmed                                    (web)"
@@ -926,15 +926,15 @@ line."
           (unless buf
             (kill-buffer)))))))
 
-(defun bibtex-completion-fallback-action (url-or-function string)
+(defun bibtex-completion-fallback-action (url-or-function search-expression)
   (let ((browse-url-browser-function
           (or bibtex-completion-browser-function
               browse-url-browser-function)))
     (cond
       ((stringp url-or-function)
-        (browse-url (format url-or-function (url-hexify-string string))))
+        (browse-url (format url-or-function (url-hexify-string search-expression))))
       ((functionp url-or-function)
-        (funcall url-or-function string))
+        (funcall url-or-function search-expression))
       (t (error "Don't know how to interpret this: %s" url-or-function)))))
 
 (defun bibtex-completion-fallback-candidates ()
@@ -944,7 +944,7 @@ entry for each BibTeX file that will open that file for editing."
   (let ((bib-files (-flatten (list bibtex-completion-bibliography))))
     (-concat
       (--map (cons (s-concat "Create new entry in " (f-filename it))
-                   `(lambda (_string) (find-file ,it) (goto-char (point-max)) (newline)))
+                   `(lambda (_search-expression) (find-file ,it) (goto-char (point-max)) (newline)))
              bib-files)
       bibtex-completion-fallback-options)))
 

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -135,13 +135,13 @@ should be a single character."
 
 (defcustom bibtex-completion-fallback-options
   '(("CrossRef                                  (biblio.el)"
-     . (lambda () (biblio-lookup #'biblio-crossref-backend helm-pattern)))
+     . (lambda (string) (biblio-lookup #'biblio-crossref-backend string)))
     ("arXiv                                     (biblio.el)"
-     . (lambda () (biblio-lookup #'biblio-arxiv-backend helm-pattern)))
+     . (lambda (string) (biblio-lookup #'biblio-arxiv-backend string)))
     ("DBLP (computer science bibliography)      (biblio.el)"
-     . (lambda () (biblio--lookup-1 #'biblio-dblp-backend helm-pattern)))
+     . (lambda (string) (biblio--lookup-1 #'biblio-dblp-backend string)))
     ("HAL (French open archive)                 (biblio.el)"
-     . (lambda () (biblio--lookup-1 #'biblio-hal-backend helm-pattern)))
+     . (lambda (string) (biblio--lookup-1 #'biblio-hal-backend string)))
     ("Google Scholar                            (web)"
      . "https://scholar.google.co.uk/scholar?q=%s")
     ("Pubmed                                    (web)"
@@ -926,15 +926,15 @@ line."
           (unless buf
             (kill-buffer)))))))
 
-(defun bibtex-completion-fallback-action (url-or-function)
+(defun bibtex-completion-fallback-action (url-or-function string)
   (let ((browse-url-browser-function
           (or bibtex-completion-browser-function
               browse-url-browser-function)))
     (cond
       ((stringp url-or-function)
-        (browse-url (format url-or-function (url-hexify-string helm-pattern))))
+        (browse-url (format url-or-function (url-hexify-string string))))
       ((functionp url-or-function)
-        (funcall url-or-function))
+        (funcall url-or-function string))
       (t (error "Don't know how to interpret this: %s" url-or-function)))))
 
 (defun bibtex-completion-fallback-candidates ()
@@ -944,7 +944,7 @@ entry for each BibTeX file that will open that file for editing."
   (let ((bib-files (-flatten (list bibtex-completion-bibliography))))
     (-concat
       (--map (cons (s-concat "Create new entry in " (f-filename it))
-                   `(lambda () (find-file ,it) (goto-char (point-max)) (newline)))
+                   `(lambda (_string) (find-file ,it) (goto-char (point-max)) (newline)))
              bib-files)
       bibtex-completion-fallback-options)))
 

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -192,7 +192,7 @@ it comes out in the right buffer."
     (candidates      . bibtex-completion-fallback-candidates)
     (no-matchplugin)
     (nohighlight)
-    (action          . bibtex-completion-fallback-action))
+    (action          . (lambda (candidate) (bibtex-completion-fallback-action candidate helm-pattern))))
   "Source for online look-up.")
 
 ;; Helm-bibtex command:

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -76,6 +76,13 @@
   (let ((width (frame-width)))
     (bibtex-completion-candidates-formatter candidates width)))
 
+(defun ivy-bibtex-fallback (string)
+  "Select a fallback option for STRING. This is meant to be used as an action in `ivy-read`, with `ivy-text` as string."
+  (ivy-read "Fallback options: "
+            (bibtex-completion-fallback-candidates)
+            :caller 'ivy-bibtex-fallback
+            :action (lambda (candidate) (bibtex-completion-fallback-action (cdr candidate) string))))
+    
 ;;;###autoload
 (defun ivy-bibtex (&optional arg)
   "Search BibTeX entries using ivy.
@@ -101,7 +108,8 @@ reread."
    ("b" bibtex-completion-insert-bibtex "Insert BibTeX entry")
    ("a" bibtex-completion-add-PDF-attachment "Attach PDF to email")
    ("e" bibtex-completion-edit-notes "Edit notes")
-   ("s" bibtex-completion-show-entry "Show entry"))) 
+   ("s" bibtex-completion-show-entry "Show entry")
+   ("f" (lambda (_candidate) (ivy-bibtex-fallback ivy-text)) "Fallback options"))) 
 
 (provide 'ivy-bibtex)
 

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -76,12 +76,12 @@
   (let ((width (frame-width)))
     (bibtex-completion-candidates-formatter candidates width)))
 
-(defun ivy-bibtex-fallback (string)
-  "Select a fallback option for STRING. This is meant to be used as an action in `ivy-read`, with `ivy-text` as string."
+(defun ivy-bibtex-fallback (search-expression)
+  "Select a fallback option for SEARCH-EXPRESSION. This is meant to be used as an action in `ivy-read`, with `ivy-text` as search expression."
   (ivy-read "Fallback options: "
             (bibtex-completion-fallback-candidates)
             :caller 'ivy-bibtex-fallback
-            :action (lambda (candidate) (bibtex-completion-fallback-action (cdr candidate) string))))
+            :action (lambda (candidate) (bibtex-completion-fallback-action (cdr candidate) search-expression))))
     
 ;;;###autoload
 (defun ivy-bibtex (&optional arg)

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -25,6 +25,7 @@
 ;; this is the ivy version.
 ;;
 ;; News:
+;; - 09/20/2016: Added fallback options to ivy frontend.
 ;; - 04/18/2016: Improved support for Mendely/Jabref/Zotero way of
 ;;   referencing PDFs.
 ;; - 04/12/2016: Published ivy version of helm-bibtex.


### PR DESCRIPTION
This is done by introducing a new action offering to select a fallback
options (this is the easiest way I could think of, since ivy-read has no
builtin mechanism to simultaneously use different sources with different
matchers and actions).

To do this efficiently I made the search expression a variable of the
functions in bibtex-completion-fallback-options (helm-pattern or
ivy-text, depending on the backend). I updated the readme accordingly.

I tested with ivy and helm and everything seems to work.