### PR TITLE
"smart" formatter for latex citations

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -592,28 +592,11 @@ matching PDFs for an entry, the first is opened."
   "History list for LaTeX citation commands.")
 
 (defun bibtex-completion-format-citation-cite (keys)
-  "Formatter for LaTeX citation commands.  Prompts for the command and
-for arguments if the commands can take any."
-  (let* ((initial (when bibtex-completion-cite-default-as-initial-input bibtex-completion-cite-default-command))
-         (default (unless bibtex-completion-cite-default-as-initial-input bibtex-completion-cite-default-command))
-         (default-info (if default (format " (default \"%s\")" default) ""))
-         (cite-command (completing-read
-                        (format "Cite command%s: " default-info)
-                        bibtex-completion-cite-commands nil nil initial
-                        'bibtex-completion-cite-command-history default nil)))
-    (if (member cite-command '("nocite" "supercite"))  ; These don't want arguments.
-        (format "\\%s{%s}" cite-command (s-join ", " keys))
-      (let ((prenote  (if bibtex-completion-cite-prompt-for-optional-arguments (read-from-minibuffer "Prenote: ") ""))
-            (postnote (if bibtex-completion-cite-prompt-for-optional-arguments (read-from-minibuffer "Postnote: ") "")))
-        (if (and (string= "" prenote) (string= "" postnote))
-            (format "\\%s{%s}" cite-command (s-join ", " keys))
-          (format "\\%s[%s][%s]{%s}" cite-command prenote postnote (s-join ", " keys)))))))
-
-(defun bibtex-completion-format-citation-cite-dwim (keys)
-  "Context-dependent formatter for LaTeX citation commands.  If `reftex-mode' is on and if point is inside a citation macro, only adds keys to it, otherwise inserts a citation with `bibtex-completion-format-citation-cite'."
+  "Formatter for LaTeX citation commands. Prompts for the command and
+for arguments if the commands can take any. If point is inside or just after a citation command, only adds KEYS to it."
   (let (macro)
     (cond
-     ((and (bound-and-true-p reftex-mode)
+     ((and (require 'reftex-parse nil t)
            (setq macro (reftex-what-macro 1))
            (stringp (car macro))
            (string-match "\\`\\\\cite\\|cite\\'" (car macro)))
@@ -628,7 +611,7 @@ for arguments if the commands can take any."
 		     ""
                 ", ")))
      ((and (equal (preceding-char) ?\})
-           (bound-and-true-p reftex-mode)
+           (require 'reftex-parse nil t)
            (save-excursion
              (forward-char -1)
              (setq macro (reftex-what-macro 1)))
@@ -644,7 +627,27 @@ for arguments if the commands can take any."
               (s-join ", " keys)
               "}"))
      (t
-      (bibtex-completion-format-citation-cite keys)))))
+      ;; We are not inside or right after a cite macro. Insert a full citation.
+      (let* ((initial (when bibtex-completion-cite-default-as-initial-input
+                        bibtex-completion-cite-default-command))
+             (default (unless bibtex-completion-cite-default-as-initial-input
+                        bibtex-completion-cite-default-command))
+             (default-info (if default (format " (default \"%s\")" default) ""))
+             (cite-command (completing-read
+                            (format "Cite command%s: " default-info)
+                            bibtex-completion-cite-commands nil nil initial
+                            'bibtex-completion-cite-command-history default nil)))
+        (if (member cite-command '("nocite" "supercite"))  ; These don't want arguments.
+            (format "\\%s{%s}" cite-command (s-join ", " keys))
+          (let ((prenote (if bibtex-completion-cite-prompt-for-optional-arguments
+                             (read-from-minibuffer "Prenote: ")
+                           ""))
+                (postnote (if bibtex-completion-cite-prompt-for-optional-arguments
+                              (read-from-minibuffer "Postnote: ")
+                            "")))
+            (if (and (string= "" prenote) (string= "" postnote))
+                (format "\\%s{%s}" cite-command (s-join ", " keys))
+              (format "\\%s[%s][%s]{%s}" cite-command prenote postnote (s-join ", " keys))))))))))
 
 (defun bibtex-completion-format-citation-pandoc-citeproc (keys)
   "Formatter for pandoc-citeproc citations."


### PR DESCRIPTION
Added a new function `bibtex-completion-format-citation-cite-dwim`. It uses `reftex` (if turned on) to determine if point is inside (or right after) a citation macro. If so it only adds keys to the existing citation, otherwise it calls `bibtex-completion-format-citation-cite` to insert a new citation.

I think it is especially useful for `ivy-bibtex`, because it makes it possible to quickly cite a bunch of references at once, using `ivy-call`. Otherwise one has to call `ivy-bibtex` and insert the first citation using`ivy-done`, then manually go back one char and insert a comma, then call `ivy-bibtex` again to insert the second key, manually insert a comma, call `ivy-bibtex` once agaiin, and so on.

PS sorry if I am sending you too many PRs...