### PR TITLE
Local bibliography (contd from #113)

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -949,6 +949,19 @@ entry for each BibTeX file that will open that file for editing."
              bib-files)
       bibtex-completion-fallback-options)))
 
+(defun bibtex-completion-find-local-bibliography ()
+  "Return a list of BibTeX files associated with the current file. If the current file is a BibTeX file, return this file. Otherwise, try to use `reftex' to find the associated BibTeX files. If this fails, return `bibtex-completion-bibliography'."
+  (or (and (buffer-file-name)
+           (string= (or (f-ext (buffer-file-name)) "") "bib")
+           (list (buffer-file-name)))
+      (and (buffer-file-name)
+           (require 'reftex-parse nil t)
+           (reftex-locate-bibliography-files
+            (if (fboundp 'TeX-master-directory)
+                (TeX-master-directory)
+              (file-name-directory (buffer-file-name)))))
+      bibtex-completion-bibliography))
+
 (provide 'bibtex-completion)
 
 ;; Local Variables:

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -269,15 +269,11 @@ the directories listed in `bibtex-completion-library-path'."
   :group 'bibtex-completion
   :type 'string)
 
-(defvar bibtex-completion-bibliography-hash nil
-  "The hash of the content of the configured bibliography
-files.  If this hash has not changed since the bibliography was
-last parsed, a cached version of the parsed bibliography will be
-used.")
+(defvar bibtex-completion-cache '((global "") (local ""))
+  "A cache storing the hash of the bibliography content and the corresponding list of candidates, obtained when the bibliography was last parsed. When the current bibliography hash is identical to the cached hash, the cached list of candidates is reused, otherwise the bibliography is reparsed. The global and local bibliographies are cached separately.")
 
-(defvar bibtex-completion-cached-candidates nil
-  "The a list of candidates obtained when the configured
-bibliography files were last parsed.")
+(defvar bibtex-completion-bibliography-type 'global
+  "Whether to use the global or local bibliography.")
 
 
 (defun bibtex-completion-init ()
@@ -303,8 +299,9 @@ before being saved."
           (-flatten (list bibtex-completion-bibliography)))
     ;; Check hash of bibliography and reparse if necessary:
     (let ((bibliography-hash (secure-hash 'sha256 (current-buffer))))
-      (unless (and bibtex-completion-cached-candidates
-                   (string= bibtex-completion-bibliography-hash bibliography-hash))
+      (unless (and (cddr (assoc bibtex-completion-bibliography-type bibtex-completion-cache))
+                   (string= (cadr (assoc bibtex-completion-bibliography-type bibtex-completion-cache))
+                            bibliography-hash))
         (message "Loading bibliography ...")
         (let* ((entries (bibtex-completion-parse-bibliography))
                (entries (bibtex-completion-resolve-crossrefs entries))
@@ -312,14 +309,15 @@ before being saved."
                (entries (nreverse entries))
                (entries
                 (--map (cons (bibtex-completion-clean-string
-                                  (s-join " " (-map #'cdr it))) it)
-                           entries)))
-          (setq bibtex-completion-cached-candidates
+                              (s-join " " (-map #'cdr it))) it)
+                       entries)))
+          (setf (cddr (assoc bibtex-completion-bibliography-type bibtex-completion-cache))
                 (if (functionp formatter)
                     (funcall formatter entries)
                   entries)))
-        (setq bibtex-completion-bibliography-hash bibliography-hash))
-      bibtex-completion-cached-candidates)))
+        (setf (cadr (assoc bibtex-completion-bibliography-type bibtex-completion-cache))
+              bibliography-hash))
+      (cddr (assoc bibtex-completion-bibliography-type bibtex-completion-cache)))))
 
 (defun bibtex-completion-resolve-crossrefs (entries)
   "Expand all entries with fields from cross-references entries."
@@ -960,7 +958,8 @@ entry for each BibTeX file that will open that file for editing."
             (if (fboundp 'TeX-master-directory)
                 (TeX-master-directory)
               (file-name-directory (buffer-file-name)))))
-      bibtex-completion-bibliography))
+      (and (setq bibtex-completion-bibliography-type 'global)
+           bibtex-completion-bibliography)))
 
 (provide 'bibtex-completion)
 

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -205,7 +205,7 @@ With a prefix ARG, the cache is invalidated and the bibliography
 reread."
   (interactive "P")
   (when arg
-    (setq bibtex-completion-bibliography-hash ""))
+    (setf (cadr (assoc bibtex-completion-bibliography-type bibtex-completion-cache)) ""))
   (helm :sources (list helm-source-bibtex helm-source-fallback-options)
         :full-frame helm-bibtex-full-frame
         :buffer "*helm bibtex*"
@@ -217,7 +217,8 @@ reread."
 
 With a prefix ARG the cache is invalidated and the bibliography reread."
   (interactive "P")
-  (let ((bibtex-completion-bibliography (bibtex-completion-find-local-bibliography)))
+  (let* ((bibtex-completion-bibliography-type 'local)
+         (bibtex-completion-bibliography (bibtex-completion-find-local-bibliography)))
     (helm-bibtex arg)))
 
 (provide 'helm-bibtex)

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -211,6 +211,15 @@ reread."
         :buffer "*helm bibtex*"
         :candidate-number-limit 500))
 
+;;;###autoload
+(defun helm-bibtex-with-local-bibliography (&optional arg)
+  "Search BibTeX entries with local bibliography.
+
+With a prefix ARG the cache is invalidated and the bibliography reread."
+  (interactive "P")
+  (let ((bibtex-completion-bibliography (bibtex-completion-find-local-bibliography)))
+    (helm-bibtex arg)))
+
 (provide 'helm-bibtex)
 
 ;; Local Variables:

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -88,7 +88,7 @@
 With a prefix ARG the cache is invalidated and the bibliography reread."
   (interactive "P")
   (when arg
-    (setq bibtex-completion-bibliography-hash ""))
+    (setf (cadr (assoc bibtex-completion-bibliography-type bibtex-completion-cache)) ""))
   (bibtex-completion-init)
   (ivy-read "BibTeX Items: "
             (bibtex-completion-candidates 'ivy-bibtex-candidates-formatter)
@@ -101,7 +101,8 @@ With a prefix ARG the cache is invalidated and the bibliography reread."
 
 With a prefix ARG the cache is invalidated and the bibliography reread."
   (interactive "P")
-  (let ((bibtex-completion-bibliography (bibtex-completion-find-local-bibliography)))
+  (let* ((bibtex-completion-bibliography-type 'local)
+         (bibtex-completion-bibliography (bibtex-completion-find-local-bibliography)))
     (ivy-bibtex arg)))
 
 (ivy-set-actions

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -85,8 +85,7 @@
 (defun ivy-bibtex (&optional arg)
   "Search BibTeX entries using ivy.
 
-With a prefix ARG the cache is invalidated and the bibliography
-reread."
+With a prefix ARG the cache is invalidated and the bibliography reread."
   (interactive "P")
   (when arg
     (setq bibtex-completion-bibliography-hash ""))
@@ -95,6 +94,15 @@ reread."
             (bibtex-completion-candidates 'ivy-bibtex-candidates-formatter)
             :caller 'ivy-bibtex
             :action ivy-bibtex-default-action))
+
+;;;###autoload
+(defun ivy-bibtex-with-local-bibliography (&optional arg)
+  "Search BibTeX entries with local bibliography.
+
+With a prefix ARG the cache is invalidated and the bibliography reread."
+  (interactive "P")
+  (let ((bibtex-completion-bibliography (bibtex-completion-find-local-bibliography)))
+    (ivy-bibtex arg)))
 
 (ivy-set-actions
  'ivy-bibtex


### PR DESCRIPTION
/cc @jagrg who wrote PR #113 

So as I commented there, I think it is more convenient at that point to send you a new PR.

There are two commits.

The first one simply adds the function `bibtex-completion--get-local-databases` from #113 (I took the liberty to rename it to `bibtex-completion-find-local-bibliography` which I think is more in line with the way you name functions in the package...), with the small change from my last comment, as well as the `-with-local-bibliography` variants of `helm-bibtex` and `ivy-bibtex`.

The second commit implements a separate local cache so that the `-with-local` variants don't invalidate the cache for the standard ones. The idea is simply to replace the variables `bibtex-completion-bibliography-hash` and `bibtex-completion-cached-candidates` with an alist (named `bibtex-completion-cache`) of the form

    (('global HASH CANDIDATES) ('local HASH CANDIDATES))

and to add a variable `bibtex-completion-bibliography-type`  which is `'global` by default but is let-bound to `'local` by the `-wich-local` variants. Then we only need to change a couple of lines so that `bibtex-completion-candidates` uses this latter variable to read and write at the right place in the cache.

I measured loading time with crypto.bib and the following code

```
(defmacro measure-time (&rest body)
  "Measure the time it takes to evaluate BODY."
  `(let ((time (current-time)))
     ,@body
     (message "%.06f" (float-time (time-since time)))))
(require 'bibtex-completion)
(setq bibtex-completion-bibliography '("/c/temp/abbrev0.bib" "/c/temp/crypto.bib"))
(measure-time (bibtex-completion-candidates))
```

I obtained similar loading time before and after the change, around 23.9 seconds.

From here, one possibility that seems appealing to me would be to generalize the idea further by storing the cache data for each bibliography file separately rather than for the whole bibliography. Basically we would simply need to replace the `'global` and `'local` symbols by the bibliography file names in `bibtex-completion-cache`, and make `bibtex-completion-candidates` parse and process entries file per file rather than globally. This would be more efficient if the user modifies one out of several bibliography files or has files that are common to the global and local bibliographies. Note that the cross-references would then also be resolved file per file rather than globally, I don't know if this problematic. Anyway, I can try it if you are interested.