### PR TITLE
make ivy-bibtex faster by only formatting displayed candidates

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -284,15 +284,12 @@ actually exist."
                   (user-error "BibTeX file %s could not be found." file)))
         (-flatten (list bibtex-completion-bibliography))))
 
-(defun bibtex-completion-candidates (&optional formatter)
+(defun bibtex-completion-candidates ()
   "Reads the BibTeX files and returns a list of conses, one for
 each entry.  The first element of these conses is a string
 containing authors, editors, title, year, type, and key of the
 entry.  This is string is used for matching.  The second element
-is the entry (only the fields listed above) as an alist.
-
-If non-nil, the entries are passed to the function FORMATTER
-before being saved."
+is the entry (only the fields listed above) as an alist."
   ;; Open configured bibliographies in temporary buffer:
   (with-temp-buffer
     (mapc #'insert-file-contents
@@ -312,9 +309,7 @@ before being saved."
                               (s-join " " (-map #'cdr it))) it)
                        entries)))
           (setf (cddr (assoc bibtex-completion-bibliography-type bibtex-completion-cache))
-                (if (functionp formatter)
-                    (funcall formatter entries)
-                  entries)))
+                entries))
         (setf (cadr (assoc bibtex-completion-bibliography-type bibtex-completion-cache))
               bibliography-hash))
       (cddr (assoc bibtex-completion-bibliography-type bibtex-completion-cache)))))

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -522,53 +522,32 @@ values."
                concat (car p))
     nil))
 
-(defun bibtex-completion-normalize-candidate (candidate)
-  "Extract key from CANDIDATE."
-  (cond ((stringp candidate)
-         candidate)
-        ((stringp (cdr-safe candidate))
-         (cdr candidate))))
-
-(defun bibtex-completion-normalize-candidates (candidates)
-  "Normalize CANDIDATES to a list of candidates for each action
-function."
-  (cond
-   ;; single cons cell
-   ((stringp (cdr-safe candidates))
-    (list (cdr candidates)))
-   ((listp candidates)
-    (-map #'bibtex-completion-normalize-candidate candidates))
-   (t
-    (list candidates))))
-
 
-(defun bibtex-completion-open-pdf (candidates)
+(defun bibtex-completion-open-pdf (keys)
   "Open the PDFs associated with the marked entries using the
 function specified in `bibtex-completion-pdf-open-function'.  All paths
 in `bibtex-completion-library-path' are searched.  If there are several
 matching PDFs for an entry, the first is opened."
   (--if-let
       (-flatten
-       (-map 'bibtex-completion-find-pdf
-             (bibtex-completion-normalize-candidates candidates)))
+       (-map 'bibtex-completion-find-pdf keys))
       (-each it bibtex-completion-pdf-open-function)
     (message "No PDF(s) found.")))
 
-(defun bibtex-completion-open-url-or-doi (candidates)
+(defun bibtex-completion-open-url-or-doi (keys)
   "Open the associated URL or DOI in a browser."
-  (let ((keys (bibtex-completion-normalize-candidates candidates)))
-    (dolist (key keys)
-      (let* ((entry (bibtex-completion-get-entry key))
-             (url (bibtex-completion-get-value "url" entry))
-             (doi (bibtex-completion-get-value "doi" entry))
-             (browse-url-browser-function
-              (or bibtex-completion-browser-function
-                  browse-url-browser-function)))
-        (if url (browse-url url)
-          (if doi (browse-url
-                   (s-concat "http://dx.doi.org/" doi)))
-          (message "No URL or DOI found for this entry: %s"
-                   key))))))
+  (dolist (key keys)
+    (let* ((entry (bibtex-completion-get-entry key))
+           (url (bibtex-completion-get-value "url" entry))
+           (doi (bibtex-completion-get-value "doi" entry))
+           (browse-url-browser-function
+            (or bibtex-completion-browser-function
+                browse-url-browser-function)))
+      (if url (browse-url url)
+        (if doi (browse-url
+                 (s-concat "http://dx.doi.org/" doi)))
+        (message "No URL or DOI found for this entry: %s"
+                 key)))))
 
 (defun bibtex-completion-format-citation-default (keys)
   "Default formatter for keys, separates multiple keys with commas."
@@ -657,20 +636,18 @@ omitted."
                 for pdfs = (bibtex-completion-find-pdf key)
                 append (--map (format "[[%s][%s]]" it key) pdfs))))
 
-(defun bibtex-completion-insert-citation (candidates)
+(defun bibtex-completion-insert-citation (keys)
   "Insert citation at point.  The format depends on
 `bibtex-completion-format-citation-functions'."
-  (let ((keys (bibtex-completion-normalize-candidates candidates))
-        (format-function
+  (let ((format-function
          (cdr (or (assoc major-mode bibtex-completion-format-citation-functions)
                   (assoc 'default   bibtex-completion-format-citation-functions)))))
     (insert
      (funcall format-function keys))))
 
-(defun bibtex-completion-insert-reference (candidates)
+(defun bibtex-completion-insert-reference (keys)
   "Insert a reference for each selected entry."
-  (let* ((keys (bibtex-completion-normalize-candidates candidates))
-         (refs (--map
+  (let* ((refs (--map
                 (s-word-wrap fill-column
                              (concat "\n- " (bibtex-completion-apa-format-reference it)))
                 keys)))
@@ -680,9 +657,7 @@ omitted."
   "Returns a plain text reference in APA format for the
 publication specified by KEY."
   (let*
-   ((key (bibtex-completion-normalize-candidate key))
-    (entry (bibtex-completion-get-entry
-            (bibtex-completion-normalize-candidate key)))
+   ((entry (bibtex-completion-get-entry key))
     (ref (pcase (downcase (bibtex-completion-get-value "=type=" entry))
            ("article"
             (s-format
@@ -826,20 +801,17 @@ defined.  Surrounding curly braces are stripped."
           value))
       default)))
 
-(defun bibtex-completion-insert-key (candidates)
+(defun bibtex-completion-insert-key (keys)
   "Insert BibTeX key at point."
-  (let ((keys (bibtex-completion-normalize-candidates candidates)))
-    (insert
-     (funcall 'bibtex-completion-format-citation-default keys))))
+  (insert
+   (funcall 'bibtex-completion-format-citation-default keys)))
 
-(defun bibtex-completion-insert-bibtex (candidates)
+(defun bibtex-completion-insert-bibtex (keys)
   "Insert BibTeX key at point."
-  (let ((keys (bibtex-completion-normalize-candidates candidates)))
-    (insert (s-join "\n" (--map (bibtex-completion-make-bibtex it) keys)))))
+  (insert (s-join "\n" (--map (bibtex-completion-make-bibtex it) keys))))
 
 (defun bibtex-completion-make-bibtex (key)
-  (let* ((entry (bibtex-completion-get-entry
-                 (bibtex-completion-normalize-candidate key)))
+  (let* ((entry (bibtex-completion-get-entry key))
          (entry-type (bibtex-completion-get-value "=type=" entry)))
     (format "@%s{%s,\n%s}\n"
             entry-type key
@@ -854,12 +826,11 @@ defined.  Surrounding curly braces are stripped."
              concat
              (format "  %s = %s,\n" name value)))))
 
-(defun bibtex-completion-add-PDF-attachment (candidates)
+(defun bibtex-completion-add-PDF-attachment (keys)
   "Attach the PDFs of the selected entries where available."
   (--if-let
       (-flatten
-       (-map 'bibtex-completion-find-pdf
-             (bibtex-completion-normalize-candidates candidates)))
+       (-map 'bibtex-completion-find-pdf keys))
       (-each it 'mml-attach-file)
     (message "No PDF(s) found.")))
 
@@ -892,9 +863,9 @@ line."
         (delete-window window)
       (switch-to-buffer (other-buffer)))))
 
-(defun bibtex-completion-edit-notes (key)
-  "Open the notes associated with the entry using `find-file'."
-  (let ((key (bibtex-completion-normalize-candidate key)))
+(defun bibtex-completion-edit-notes (keys)
+  "Open the notes associated with the selected entries using `find-file'."
+  (dolist (key keys)
     (if (and bibtex-completion-notes-path
              (f-directory? bibtex-completion-notes-path))
                                         ; One notes file per publication:
@@ -936,11 +907,11 @@ line."
   (or (get-file-buffer file)
       (find-buffer-visiting file)))
 
-(defun bibtex-completion-show-entry (key)
-  "Show the entry in the BibTeX file."
+(defun bibtex-completion-show-entry (keys)
+  "Show the first selected entry in the BibTeX file."
   (catch 'break
     (dolist (bibtex-file (-flatten (list bibtex-completion-bibliography)))
-      (let ((key (bibtex-completion-normalize-candidate key))
+      (let ((key (car keys))
             (buf (bibtex-completion-buffer-visiting bibtex-file)))
         (find-file bibtex-file)
         (goto-char (point-min))

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -493,14 +493,6 @@ find a PDF file."
 
 
 
-(defun bibtex-completion-candidates-formatter (candidates width)
-  "Formats BibTeX entries for display in results list."
-  (cl-loop
-   for entry in candidates
-   for entry = (cdr entry)
-   for entry-key = (bibtex-completion-get-value "=key=" entry)
-   collect (cons (bibtex-completion-format-entry entry width) entry-key)))
-
 (defun bibtex-completion-format-entry (entry width)
   "Formats a BibTeX entry for display in results list."
   (let* ((fields (list (if (assoc-string "author" entry 'case-fold) "author" "editor")

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -499,20 +499,20 @@ find a PDF file."
    for entry in candidates
    for entry = (cdr entry)
    for entry-key = (bibtex-completion-get-value "=key=" entry)
-   if (assoc-string "author" entry 'case-fold)
-     for fields = '("author" "title" "year" "=has-pdf=" "=has-note=" "=type=")
-   else
-     for fields = '("editor" "title" "year" "=has-pdf=" "=has-note=" "=type=")
-   for fields = (-map (lambda (it)
-                        (bibtex-completion-clean-string
+   collect (cons (bibtex-completion-format-entry entry width) entry-key)))
+
+(defun bibtex-completion-format-entry (entry width)
+  "Formats a BibTeX entry for display in results list."
+  (let* ((fields (list (if (assoc-string "author" entry 'case-fold) "author" "editor")
+                       "title" "year" "=has-pdf=" "=has-note=" "=type="))
+         (fields (-map (lambda (it)
+                         (bibtex-completion-clean-string
                           (bibtex-completion-get-value it entry " ")))
-                      fields)
-   for fields = (-update-at 0 'bibtex-completion-shorten-authors fields)
-   collect
-   (cons (s-format "$0 $1 $2 $3$4 $5" 'elt
-                   (-zip-with (lambda (f w) (truncate-string-to-width f w 0 ?\s))
-                              fields (list 36 (- width 53) 4 1 1 7)))
-         entry-key)))
+                       fields))
+         (fields (-update-at 0 'bibtex-completion-shorten-authors fields)))
+    (s-format "$0 $1 $2 $3$4 $5" 'elt
+              (-zip-with (lambda (f w) (truncate-string-to-width f w 0 ?\s))
+                         fields (list 36 (- width 53) 4 1 1 7)))))
 
 
 (defun bibtex-completion-clean-string (s)

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -170,6 +170,8 @@ it comes out in the right buffer."
 (helm-bibtex-helmify-action bibtex-completion-insert-key helm-bibtex-insert-key)
 (helm-bibtex-helmify-action bibtex-completion-insert-bibtex helm-bibtex-insert-bibtex)
 (helm-bibtex-helmify-action bibtex-completion-add-PDF-attachment helm-bibtex-add-PDF-attachment)
+(helm-bibtex-helmify-action bibtex-completion-edit-notes helm-bibtex-edit-notes)
+(helm-bibtex-helmify-action bibtex-completion-show-entry helm-bibtex-show-entry)
 
 ;; Helm sources:
 
@@ -186,8 +188,8 @@ it comes out in the right buffer."
              "Insert BibTeX key"          'helm-bibtex-insert-key
              "Insert BibTeX entry"        'helm-bibtex-insert-bibtex
              "Attach PDF to email"        'helm-bibtex-add-PDF-attachment
-             "Edit notes"                 'bibtex-completion-edit-notes
-             "Show entry"                 'bibtex-completion-show-entry))
+             "Edit notes"                 'helm-bibtex-edit-notes
+             "Show entry"                 'helm-bibtex-show-entry))
   "Source for searching in BibTeX files.")
 
 (defvar helm-source-fallback-options

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -144,8 +144,12 @@ nil, the window will split below."
     (1- (window-body-width))))
 
 (defun helm-bibtex-candidates-formatter (candidates _)
-  (let ((width (with-helm-window (helm-bibtex-window-width))))
-    (bibtex-completion-candidates-formatter candidates width)))
+  (cl-loop
+   with width = (with-helm-window (helm-bibtex-window-width))
+   for entry in candidates
+   for entry = (cdr entry)
+   for entry-key = (bibtex-completion-get-value "=key=" entry)
+   collect (cons (bibtex-completion-format-entry entry width) entry-key)))
 
 ;; Warp bibtex-completion actions with some helm-specific code:
 

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -73,7 +73,7 @@
 (require 'ivy)
 (require 'bibtex-completion)
 
-(defcustom ivy-bibtex-default-action 'bibtex-completion-open-pdf
+(defcustom ivy-bibtex-default-action 'ivy-bibtex-open-pdf
   "The default action for the `ivy-bibtex` command."
   :group 'bibtex-completion
   :type 'function)
@@ -84,13 +84,28 @@
          (entry (cdr (nth idx (ivy-state-collection ivy-last)))))
     (bibtex-completion-format-entry entry width)))
 
+(defmacro ivy-bibtex-ivify-action (action name)
+  "Wraps the function ACTION in another function named NAME which
+extracts the key from the candidate selected in ivy and passes it to ACTION."
+  `(defun ,name (candidate)
+     (let ((key (cdr (assoc "=key=" (cdr candidate)))))
+       (,action (list key)))))
+
+(ivy-bibtex-ivify-action bibtex-completion-open-pdf ivy-bibtex-open-pdf)
+(ivy-bibtex-ivify-action bibtex-completion-open-url-or-doi ivy-bibtex-open-url-or-doi)
+(ivy-bibtex-ivify-action bibtex-completion-insert-citation ivy-bibtex-insert-citation)
+(ivy-bibtex-ivify-action bibtex-completion-insert-reference ivy-bibtex-insert-reference)
+(ivy-bibtex-ivify-action bibtex-completion-insert-key ivy-bibtex-insert-key)
+(ivy-bibtex-ivify-action bibtex-completion-insert-bibtex ivy-bibtex-insert-bibtex)
+(ivy-bibtex-ivify-action bibtex-completion-add-PDF-attachment ivy-bibtex-add-PDF-attachment)
+
 (defun ivy-bibtex-fallback (search-expression)
   "Select a fallback option for SEARCH-EXPRESSION. This is meant to be used as an action in `ivy-read`, with `ivy-text` as search expression."
   (ivy-read "Fallback options: "
             (bibtex-completion-fallback-candidates)
             :caller 'ivy-bibtex-fallback
             :action (lambda (candidate) (bibtex-completion-fallback-action (cdr candidate) search-expression))))
-    
+
 ;;;###autoload
 (defun ivy-bibtex (&optional arg)
   "Search BibTeX entries using ivy.
@@ -121,15 +136,15 @@ With a prefix ARG the cache is invalidated and the bibliography reread."
 
 (ivy-set-actions
  'ivy-bibtex
- '(("p" bibtex-completion-open-pdf "Open PDF file (if present)")
-   ("u" bibtex-completion-open-url-or-doi "Open URL or DOI in browser")
-   ("c" bibtex-completion-insert-citation "Insert citation")
-   ("r" bibtex-completion-insert-reference "Insert reference")
-   ("k" bibtex-completion-insert-key "Insert BibTeX key")
-   ("b" bibtex-completion-insert-bibtex "Insert BibTeX entry")
-   ("a" bibtex-completion-add-PDF-attachment "Attach PDF to email")
-   ("e" bibtex-completion-edit-notes "Edit notes")
-   ("s" bibtex-completion-show-entry "Show entry")
+ '(("p" ivy-bibtex-open-pdf "Open PDF file (if present)")
+   ("u" ivy-bibtex-open-url-or-doi "Open URL or DOI in browser")
+   ("c" ivy-bibtex-insert-citation "Insert citation")
+   ("r" ivy-bibtex-insert-reference "Insert reference")
+   ("k" ivy-bibtex-insert-key "Insert BibTeX key")
+   ("b" ivy-bibtex-insert-bibtex "Insert BibTeX entry")
+   ("a" ivy-bibtex-add-PDF-attachment "Attach PDF to email")
+   ("e" ivy-bibtex-edit-notes "Edit notes")
+   ("s" ivy-bibtex-show-entry "Show entry")
    ("f" (lambda (_candidate) (ivy-bibtex-fallback ivy-text)) "Fallback options"))) 
 
 (provide 'ivy-bibtex)

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -98,6 +98,8 @@ extracts the key from the candidate selected in ivy and passes it to ACTION."
 (ivy-bibtex-ivify-action bibtex-completion-insert-key ivy-bibtex-insert-key)
 (ivy-bibtex-ivify-action bibtex-completion-insert-bibtex ivy-bibtex-insert-bibtex)
 (ivy-bibtex-ivify-action bibtex-completion-add-PDF-attachment ivy-bibtex-add-PDF-attachment)
+(ivy-bibtex-ivify-action bibtex-completion-edit-notes ivy-bibtex-edit-notes)
+(ivy-bibtex-ivify-action bibtex-completion-show-entry ivy-bibtex-show-entry)
 
 (defun ivy-bibtex-fallback (search-expression)
   "Select a fallback option for SEARCH-EXPRESSION. This is meant to be used as an action in `ivy-read`, with `ivy-text` as search expression."

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -78,9 +78,11 @@
   :group 'bibtex-completion
   :type 'function)
   
-(defun ivy-bibtex-candidates-formatter (candidates)
-  (let ((width (frame-width)))
-    (bibtex-completion-candidates-formatter candidates width)))
+(defun ivy-bibtex-display-transformer (candidate)
+  (let* ((width (frame-width))
+         (idx (get-text-property 0 'idx candidate))
+         (entry (cdr (nth idx (ivy-state-collection ivy-last)))))
+    (bibtex-completion-format-entry entry width)))
 
 (defun ivy-bibtex-fallback (search-expression)
   "Select a fallback option for SEARCH-EXPRESSION. This is meant to be used as an action in `ivy-read`, with `ivy-text` as search expression."
@@ -99,7 +101,7 @@ With a prefix ARG the cache is invalidated and the bibliography reread."
     (setf (cadr (assoc bibtex-completion-bibliography-type bibtex-completion-cache)) ""))
   (bibtex-completion-init)
   (ivy-read "BibTeX Items: "
-            (bibtex-completion-candidates 'ivy-bibtex-candidates-formatter)
+            (bibtex-completion-candidates)
             :caller 'ivy-bibtex
             :action ivy-bibtex-default-action))
 
@@ -112,6 +114,10 @@ With a prefix ARG the cache is invalidated and the bibliography reread."
   (let* ((bibtex-completion-bibliography-type 'local)
          (bibtex-completion-bibliography (bibtex-completion-find-local-bibliography)))
     (ivy-bibtex arg)))
+
+(ivy-set-display-transformer
+ 'ivy-bibtex
+ 'ivy-bibtex-display-transformer)
 
 (ivy-set-actions
  'ivy-bibtex


### PR DESCRIPTION
Currently `helm-bibtex` caches unformatted entries and only formats the filtered ones through helm's `filtered-candidates-transformer` mechanism. `ivy-bibtex`, on the other hand, formats all entries before caching them.

This difference makes `ivy-bibtex` much slower than `helm-bibtex` for large bibliographies, and this PR fixes this by making `ivy-bibtex` cache unformatted entries and only format the displayed entries through ivy's `display-transformer` mechanism. There are some differences between helm's and ivy's mechanisms, which we have to take into account, but once we do that the two frontends consistently cache unformatted entries and pass list of keys to their actions, and they are similar in terms of speed. Here are the timings in seconds that I obtain with `crypto.bib` (same methodology as in #137 ):

|      | before | after |
| --- | --- | --- |
| `bibtex-completion-candidates` | 23.8 | 23.8 |
| `helm-bibtex` | 24.0 | 24.0 |
| `ivy-bibtex` | 38.6 | 24.0 |

There are five commits in the PR. The first two are the main ones that actually do the job. The last three are just cleanup that naturally follows from the first two, in my opinion, but I don't know if you will agree so I made separate commits. A detailed explanation follows. Of course let me know if you would like me to change some things.

The first commit makes `ivy-bibtex` cache unformatted entries (like `helm-bibtex`), and then only format the displayed entries through `ivy-set-display-transformer`. Unlike helm, ivy transforms only the displayed candidates and not all the filtered ones, and it transforms them one by one. Also, the transformer function only takes as argument the string to be formatted (that is, the `car` of the candidate), and outputs the formatted string to be displayed. So we have to recover the corresponding alist (the `cdr` of the candidate) from the unformatted string. ivy makes this fast and easy by storing the candidate's index in the candidates list as a text property in the unformatted string. So we simply get the index, fetch the corresponding entry, and use its alist to generate the formatted string. To do this efficiently I separated the formatting code out of the function `bibtex-completion-candidates-formatter` into a new function `bibtex-completion-format-entry`.

Another difference between ivy's and helm's mechanisms is that ivy only transforms the candidates for display but passes the untransformed selected candidate to actions. So `ivy-bibtex` now passes a cons cell (string . alist), instead of (string . key) previously (`helm-bibtex`, on the other hand, passes a list of keys). This makes `bibtex-completion-normalize-candidates` fail to correctly pass keys to actions. The second commit fixes this. But instead of tweaking `bibtex-completion-normalize-candidates` to figure out where to find the keys to pass without knowing which frontend is used, it seemed more natural to me to let each frontend do the job of extracting and passing keys to actions. `helm-bibtex-helmify-action` makes sure that `helm-bibtex` always passes a list of keys. I simply defined an `ivy-bibtex-ivify-actions` macro to make sure that `ivy-bibtex` also passes a similar list (with a single key, since ivy does not support selecting multiple candidates).

As I said, at this point everything works and the remaining commits just do some cleanup:
- The third one moves `bibtex-completion-candidates-formatter` to `helm-bibtex.el`, since only this frontend now uses it (the new function `bibtex-completion-format-candidate`,  which is used by both frontends, remains in `bibtex-completion.el`). In fact I merged this function into `helm-bibtex-candidates-formatter`.
- The fourth one removes the optional `formatter` argument to `bibtex-completion-candidates`, since it is no longer used.
- The fifth one removes `bibtex-completion-normalize-candidates`, which I think is no longer needed since both frontends now consistently pass list of keys to actions. It seems simpler to me to let the generic action functions in `bibtex-completion.el` assume that they systematically receive list of keys, and then let each frontend modify these functions as needed.

Sorry for the lengthy explanations, I hope at least they are clear.