### PR TITLE
Added bibtex-completion-open-any

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,6 +9,7 @@ Helm-bibtex and ivy-bibtex allow you to search and manage your BibTeX bibliograp
 Ivy-bibtex is experimental at this time, lacks some features, and may be noticeably slower than helm-bibtex when used with larger bibliographies.
 
 * News
+- 2016-10-07: Added bibtex-completion-open-any, made it the default action for helm-bibtex and ivy-bibtex
 - 2016-09-29: Performance improvements in ivy-bibtex.  *Note:* If you changed your default action in ivy-bibtex, you have to rename the action, e.g. from ~bibtex-completion-insert-key~ to ~ivy-bibtex-insert-key~.  See [[#change-the-default-action][here]] for details.
 - 2016-09-20: Added fallback options to ivy frontend.
 - 2016-04-18: Improved support for Mendely/Jabref/Zotero way of referencing PDFs.
@@ -380,9 +381,9 @@ article caplan !waters
 
 ** Actions for selected publications
 
-*Helm-bibtex*: Select one or more entries (see above) and press ~<return>~ to open the PDF (default action).  Alternatively, press ~TAB~ (tabulator) to see a list of all actions.  There are: 
+*Helm-bibtex*: Select one or more entries (see above) and press ~<return>~ to open the PDF if present, or open a URL or DOI in the browser if not (default action).  Alternatively, press ~TAB~ (tabulator) to see a list of all actions.  There are: 
 
-- Open the PDF file (if present)
+- Open a PDF, or a URL or DOI
 - Open the URL or DOI in browser
 - Insert citation
 - Insert reference
@@ -392,7 +393,7 @@ article caplan !waters
 - Edit notes
 - Show entry
 
-*Ivy-bibtex*: Select an entry and press enter to open the PDF (default action).  Alternatively, press ~M-o~ to see a list of available actions.
+*Ivy-bibtex*: Select an entry and press enter to open the PDF if present, or open a URL or DOI in the browser if not (default action).  Alternatively, press ~M-o~ to see a list of available actions.
 
 ** A colleague asks for copies of your new papers
 

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -552,7 +552,7 @@ matching PDFs for an entry, the first is opened."
 (defun bibtex-completion-open-any (keys)
   "Open the PDFs associated with the marked entries using the
 function specified in `bibtex-completion-pdf-open-function'.  If no PDF is
-found, try to open a URL or DOI instead."
+found, try to open a URL or DOI in the browser instead."
   (dolist (key keys)
     (let ((pdf (bibtex-completion-find-pdf key)))
       (if pdf (funcall bibtex-completion-pdf-open-function (car pdf))
@@ -565,7 +565,7 @@ found, try to open a URL or DOI instead."
           (if url (browse-url url)
             (if doi (browse-url
                      (s-concat "http://dx.doi.org/" doi)))
-            (message "No URL or DOI found for this entry: %s"
+            (message "No PDF and no URL or DOI found for this entry: %s"
                      key)))))))
 
 (defun bibtex-completion-format-citation-default (keys)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -549,6 +549,25 @@ matching PDFs for an entry, the first is opened."
         (message "No URL or DOI found for this entry: %s"
                  key)))))
 
+(defun bibtex-completion-open-any (keys)
+  "Open the PDFs associated with the marked entries using the
+function specified in `bibtex-completion-pdf-open-function'.  If no PDF is
+found, try to open a URL or DOI instead."
+  (dolist (key keys)
+    (let ((pdf (bibtex-completion-find-pdf key)))
+      (if pdf (funcall bibtex-completion-pdf-open-function (car pdf))
+        (let* ((entry (bibtex-completion-get-entry key))
+               (url (bibtex-completion-get-value "url" entry))
+               (doi (bibtex-completion-get-value "doi" entry))
+               (browse-url-browser-function
+                (or bibtex-completion-browser-function
+                    browse-url-browser-function)))
+          (if url (browse-url url)
+            (if doi (browse-url
+                     (s-concat "http://dx.doi.org/" doi)))
+            (message "No URL or DOI found for this entry: %s"
+                     key)))))))
+
 (defun bibtex-completion-format-citation-default (keys)
   "Default formatter for keys, separates multiple keys with commas."
   (s-join ", " keys))

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -183,7 +183,6 @@ it comes out in the right buffer."
     :filtered-candidate-transformer 'helm-bibtex-candidates-formatter
     :action (helm-make-actions
              "Open PDF, URL or DOI"       'helm-bibtex-open-any             
-             "Open PDF file (if present)" 'helm-bibtex-open-pdf
              "Open URL or DOI in browser" 'helm-bibtex-open-url-or-doi
              "Insert citation"            'helm-bibtex-insert-citation
              "Insert reference"           'helm-bibtex-insert-reference

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -165,6 +165,7 @@ it comes out in the right buffer."
 
 (helm-bibtex-helmify-action bibtex-completion-open-pdf helm-bibtex-open-pdf)
 (helm-bibtex-helmify-action bibtex-completion-open-url-or-doi helm-bibtex-open-url-or-doi)
+(helm-bibtex-helmify-action bibtex-completion-open-any helm-bibtex-open-any)
 (helm-bibtex-helmify-action bibtex-completion-insert-citation helm-bibtex-insert-citation)
 (helm-bibtex-helmify-action bibtex-completion-insert-reference helm-bibtex-insert-reference)
 (helm-bibtex-helmify-action bibtex-completion-insert-key helm-bibtex-insert-key)
@@ -181,6 +182,7 @@ it comes out in the right buffer."
     :candidates 'bibtex-completion-candidates
     :filtered-candidate-transformer 'helm-bibtex-candidates-formatter
     :action (helm-make-actions
+             "Open PDF, URL or DOI"       'helm-bibtex-open-any             
              "Open PDF file (if present)" 'helm-bibtex-open-pdf
              "Open URL or DOI in browser" 'helm-bibtex-open-url-or-doi
              "Insert citation"            'helm-bibtex-insert-citation

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -96,6 +96,7 @@ extracts the key from the candidate selected in ivy and passes it to ACTION."
      (let ((key (cdr (assoc "=key=" (cdr candidate)))))
        (,action (list key)))))
 
+(ivy-bibtex-ivify-action bibtex-completion-open-any ivy-bibtex-open-any)
 (ivy-bibtex-ivify-action bibtex-completion-open-pdf ivy-bibtex-open-pdf)
 (ivy-bibtex-ivify-action bibtex-completion-open-url-or-doi ivy-bibtex-open-url-or-doi)
 (ivy-bibtex-ivify-action bibtex-completion-insert-citation ivy-bibtex-insert-citation)
@@ -143,7 +144,8 @@ With a prefix ARG the cache is invalidated and the bibliography reread."
 
 (ivy-set-actions
  'ivy-bibtex
- '(("p" ivy-bibtex-open-pdf "Open PDF file (if present)")
+ '(("o" ivy-bibtex-open-any "Open PDF if present, or try URL or DOI")
+   ;("p" ivy-bibtex-open-pdf "Open PDF file (if present)")
    ("u" ivy-bibtex-open-url-or-doi "Open URL or DOI in browser")
    ("c" ivy-bibtex-insert-citation "Insert citation")
    ("r" ivy-bibtex-insert-reference "Insert reference")


### PR DESCRIPTION
I added a new default action, which rolls open pdf and open url/doi together. My usual workflow is to open the local pdf if I have one, and if not to immediately try to open a url or doi. Having separate manual actions to accomplish this is inconvenient.

In the pull request, my new function is placed as default, which is presumptuous of me. If the idea is sound but you don't want it as default, that makes sense. Also, I have used `dolist` only, rather than the fancy functional stuff in dash.el. Again, if the idea is sound, maybe you'd prefer a dash-based solution.

So, if any of this looks sensible, I'm happy to make any alterations necessary to suit you. And if you don't like it, I'll deal with it locally for my own use.

Best,

Tyler