### PR TITLE
don't change point when searching bibtex entries

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -430,15 +430,16 @@ appended to the requested entry."
     (bibtex-completion-remove-duplicated-fields (append entry crossref))))
 
 (defun bibtex-completion-get-entry1 (entry-key &optional do-not-find-pdf)
-  (with-temp-buffer
-    (mapc #'insert-file-contents
-          (-flatten (list bibtex-completion-bibliography)))
-    (goto-char (point-min))
-    (re-search-forward (concat "^@\\(" parsebib--bibtex-identifier
-                               "\\)[[:space:]]*[\(\{][[:space:]]*"
-                               (regexp-quote entry-key) "[[:space:]]*,"))
-    (let ((entry-type (match-string 1)))
-      (reverse (bibtex-completion-prepare-entry (parsebib-read-entry entry-type) nil do-not-find-pdf)))))
+  (save-excursion
+    (with-temp-buffer
+      (mapc #'insert-file-contents
+            (-flatten (list bibtex-completion-bibliography)))
+      (goto-char (point-min))
+      (re-search-forward (concat "^@\\(" parsebib--bibtex-identifier
+                                "\\)[[:space:]]*[\(\{][[:space:]]*"
+                                (regexp-quote entry-key) "[[:space:]]*,"))
+      (let ((entry-type (match-string 1)))
+        (reverse (bibtex-completion-prepare-entry (parsebib-read-entry entry-type) nil do-not-find-pdf))))))
 
 (defun bibtex-completion-find-pdf-in-field (key-or-entry)
   "Returns the path of the PDF specified in the field


### PR DESCRIPTION
In my bibliography notes file, I have entries similar to this one
```
** 2003 - Software Defined Radio: Enabling Technologies
   :PROPERTIES:
   :Custom_ID: tuttlebee2003software
   :AUTHOR:   Tuttlebee
   :YEAR:     2003
   :END:
   cite:tuttlebee2003software
```
When the point is on ```cite:...```, opening the context menu moves the point to the end of the ```Custom_ID``` line. Subsequent actions like opening the bibtex entry, therefore, fail as the point is no longer on a bibtex key.

Debugging showed that the ```with-temp-buffer``` function of ```bibtex-completion-get-entry1``` does not save the point and should be wrapped in a ```save-excursion```.

(I have no idea about lisp, so there might be a much nicer way to do this)
