### PR TITLE
Handle the case where the pdf-field exists but is empty.

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -478,7 +478,7 @@ file is specified, or if the specified file does not exist, or if
                           (--map (f-join it path file-name)
                                  (-flatten bibtex-completion-library-path)))) ; Jabref #100
            for result = (-first 'f-exists? paths)
-           if result collect result)))))))
+           if (not (s-blank-str? result)) collect result)))))))
 
 (defun bibtex-completion-find-pdf-in-library (key-or-entry)
   "Searches the directories in `bibtex-completion-library-path' for a


### PR DESCRIPTION
In the rare case when the `bibtex-completion-pdf-field' field exists for
a particular bibtex entry, but the file(s) it points to are just the empty
string, `bibtex-completion-find-pdf-in-field' should return `nil' instead
of "".