### PR TITLE
Fix bibtex-completion-get-value for multi-line values with braces

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -994,7 +994,7 @@ defined.  Surrounding curly braces are stripped."
          (replace-regexp-in-string
           "\\(^[[:space:]]*[\"{][[:space:]]*\\)\\|\\([[:space:]]*[\"}][[:space:]]*$\\)"
           ""
-          value))
+          (s-collapse-whitespace value)))
       default)))
 
 (defun bibtex-completion-insert-key (keys)


### PR DESCRIPTION
When a BibTeX entry has a value that has multiple lines and those
lines contain curly braces, the brace-stripping code leaves behind
extraneous braces.

For the following BibTeX entry

    @article{Paxton2015,
      author = {{Paxton}, B. and {Marchant}, P. and {Schwab}, J. and {Bauer}, E.~B. and
    	{Bildsten}, L. and {Cantiello}, M. and {Dessart}, L. and {Farmer}, R. and
    	{Hu}, H. and {Langer}, N. and {Townsend}, R.~H.~D. and {Townsley}, D.~M. and
    	{Timmes}, F.~X.},
      title = "{Modules for Experiments in Stellar Astrophysics (MESA): Binaries, Pulsations, and Explosions}",
      journal = {\apjs},
      archivePrefix = "arXiv",
      eprint = {1506.03146},
      primaryClass = "astro-ph.SR",
      keywords = {binaries: general, methods: numerical, nuclear reactions, nucleosynthesis, abundances, shock waves, stars: evolution, stars: oscillations},
      year = 2015,
      month = sep,
      volume = 220,
      eid = {15},
      pages = {15},
      doi = {10.1088/0067-0049/220/1/15},
      adsurl = {http://adsabs.harvard.edu/abs/2015ApJS..220...15P},
      adsnote = {Provided by the SAO/NASA Astrophysics Data System},
    }

the "Insert reference" action produces the text

    - Paxton, B., Marchant, P., Schwab, J., Bauer, E.~B., Bildsten}, L.,
      Cantiello, M., Dessart, L., Farmer, R., Hu}, H., Langer, N., Townsend,
      R.~H.~D., Townsley, D.~M., Timmes}, F., .. (2015). Modules for
      Experiments in Stellar Astrophysics (MESA): Binaries, Pulsations, and
      Explosions. \apjs, 220(),
      15. http://dx.doi.org/10.1088/0067-0049/220/1/15

Note the extra `}`s in the author list.  Since the authors list spans
multiple lines, the leading `{` got stripped off of each one, leaving
its mate behind.

If we make sure that the multiple lines are joined (via an application
of s-collapse-whitespace) befre the brace stripping happens, then just
the outermost ones are stripped.

After this patch, the "Insert reference" action produces the text

    - Paxton, B., Marchant, P., Schwab, J., Bauer, E.~B., Bildsten, L.,
      Cantiello, M., Dessart, L., Farmer, R., Hu, H., Langer, N., Townsend,
      R.~H.~D., Townsley, D.~M., Timmes, F.~X., .. (2015). Modules for
      Experiments in Stellar Astrophysics (MESA): Binaries, Pulsations, and
      Explosions. \apjs, 220(),
      15. http://dx.doi.org/10.1088/0067-0049/220/1/15