### PR TITLE
Make 'bibtex-completion-find-pdf-in-field' return only pdf

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -562,6 +562,7 @@ file is specified, or if the specified file does not exist, or if
                           (--map (f-join it path file-name)
                                  (-flatten bibtex-completion-library-path)))) ; Jabref #100
            for result = (-first 'f-exists? paths)
+           if (string-match "application/pdf" (nth 2 record))
            if (not (s-blank-str? result)) collect result)))))))
 
 (defun bibtex-completion-find-pdf-in-library (key-or-entry)


### PR DESCRIPTION
`bibtex-completion-find-pdf-in-field` returned any file in the 'field' entry.
Now it checks the file mime type and only return pdf files.

It is now impossible to have access to other files than pdf, 
maybe a nice helm menu to choose which file you want to open (when they are more than one of them) will be nice ?
I will take a look at that.