### PR TITLE
defcustom uses wrong type for some variables

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -218,13 +218,13 @@ browser in `helm-browse-url-default-browser-alist'"
   "The fields that are used for searching in addition to author,
 editor, title, year, BibTeX key, and entry type."
   :group 'bibtex-completion
-  :type 'list)
+  :type '(repeat string))
 
 (defcustom bibtex-completion-no-export-fields nil
   "A list of fields that should be ignored when exporting BibTeX
 entries."
   :group 'bibtex-completion
-  :type 'list)
+  :type '(repeat string))
 
 (defcustom bibtex-completion-cite-commands '("cite" "Cite" "parencite"
 "Parencite" "footcite" "footcitetext" "textcite" "Textcite"

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -99,7 +99,7 @@ directory.  In the latter case, bibtex-completion assumes that the
 names of the note files are composed of the BibTeX-key plus a
 suffix that is specified in `bibtex-completion-notes-extension'."
   :group 'bibtex-completion
-  :type '(choice file directory))
+  :type '(choice file directory (const nil)))
 
 (defcustom bibtex-completion-notes-template-multiple-files
   "#+TITLE: Notes on: ${author} (${year}): ${title}\n\n"


### PR DESCRIPTION
Customization variables `bibtex-completion-addtional-search-fields` and `bibtex-completion-no-export-fields` are defined as `:type 'list`. However, they should be `:type '(repeat string)`. The `list` type is intended for use with a list of fixed length, where each element is a set type (and potentially a different type). In contrast, `repeat` type is for lists of variable length, but each element is the same type.

The interface as is does work, but the customization interface is more helpful with the correct type. As it is now:

```
Hide bibtex-completion-additional-search-fields: nil
   [ State ]: STANDARD. (mismatch)
   The fields that are used for searching in addition to author, Hide
   editor, title, year, BibTeX key, and entry type.
Groups: [Bibtex Completion]
```

Using the repeat definition:
```
Hide Bibtex Completion Additional Search Fields:
[INS]
   [ State ]: STANDARD.
   The fields that are used for searching in addition to author, Hide
   editor, title, year, BibTeX key, and entry type.
Groups: [Bibtex Completion]
```

There are two key differences - Emacs reports a mismatch in the first version, and the second version provides an [INS] widget to add new strings to the list.
