### PR TITLE
Escape regexp chars to avoid creating malformed/mismatched regexps

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -617,7 +617,7 @@ find a PDF file."
                                 (save-restriction
                                   (widen)
                                   (goto-char (point-min))
-                                  (re-search-forward (format bibtex-completion-notes-key-pattern entry-key) nil t))))))
+                                  (re-search-forward (format bibtex-completion-notes-key-pattern (regexp-quote entry-key)) nil t))))))
                       (cons (cons "=has-note=" bibtex-completion-notes-symbol) entry)
                     entry))
            ; Remove unwanted fields:


### PR DESCRIPTION
Escape/quote special regexp characters in bibtex keys to avoid inadvertently mis-translating the keys when creating this search regexp.

Typically this is not encountered since keys ideally omit punctuation, but a wild "[" in a key yields an invalid regexp or a "*" likely yields a non-matching regexp.  In practicality, this only likely to occur with dirty data, but this change improves the durability of the code.