### PR TITLE
formatting references truncated the first author

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -965,7 +965,7 @@ guidelines.  Return DEFAULT if FIELD is not present in ENTRY."
                  ((= l 1) (car authors))
                  ((< l 8) (concat (s-join ", " (-butlast authors))
                                   ", & " (-last-item authors)))
-                 (t (concat (s-join ", " (-slice authors 1 8)) ", …"))))))
+                 (t (concat (s-join ", " (-slice authors 0 7)) ", …"))))))
 
 (defun bibtex-completion-apa-format-editors (value)
   (cl-loop for a in (s-split " and " value t)


### PR DESCRIPTION
In the function bibtex-completion-apa-format-authors, long author lists
were truncated to eight authors using the function -slice. However, the
call to slice used the hard-coded arguments 1 and 8 to delimit the first
and last authors to retain. This incorrect, as the first list element
is 0 in -slice (i.e., it is 0-indexed.)