### PR TITLE
find local bibliography more robustly

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1191,11 +1191,8 @@ BibTeX files. If this fails, return
            (string= (or (f-ext (buffer-file-name)) "") "bib")
            (list (buffer-file-name)))
       (and (buffer-file-name)
-           (require 'reftex-parse nil t)
-           (reftex-locate-bibliography-files
-            (if (fboundp 'TeX-master-directory)
-                (TeX-master-directory)
-              (file-name-directory (buffer-file-name)))))
+           (require 'reftex-cite nil t)
+           (reftex-get-bibfile-list))
       bibtex-completion-bibliography))
 
 (provide 'bibtex-completion)


### PR DESCRIPTION
Using function `reftex-get-bibfile-list` from reftex-cite.el instead
of `reftex-locate-bibliography-files` from reftex-parse.el. This is
more robust because bibliography commands are found in all the
document's files (master file and others), not only in the current buffer.

I think this should fix #184.