### PR TITLE
preselect bibtex entry at point

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1195,6 +1195,38 @@ BibTeX files. If this fails, return
            (reftex-get-bibfile-list))
       bibtex-completion-bibliography))
 
+(defun bibtex-completion-key-at-point ()
+  "Return the key of the BibTeX entry at point. If the current
+file is a BibTeX file, return the key of the entry at
+point. Otherwise, try to use `reftex' to check whether point is
+at a citation macro, and if so return the key at
+point. Otherwise, if the current file is an org-mode file, return
+the value of `org-bibtex-key-property' (or
+default to \"CUSTOM_ID\"). Otherwise, return nil."
+  (or (and (eq major-mode 'bibtex-mode)
+           (save-excursion
+             (bibtex-beginning-of-entry)
+             (and (looking-at bibtex-entry-maybe-empty-head)
+                  (bibtex-key-in-head))))
+      (and (require 'reftex-parse nil t)
+           (save-excursion
+             (skip-chars-backward "[:space:],;}")
+             (let ((macro (reftex-what-macro 1)))
+               (and (stringp (car macro))
+                    (string-match "\\`\\\\cite\\|cite\\'" (car macro))
+                    (thing-at-point 'symbol)))))
+      (and (eq major-mode 'org-mode)
+           (let (key)
+             (and (setq key (org-entry-get nil
+                                           (if (boundp 'org-bibtex-key-property)
+                                               org-bibtex-key-property
+                                             "CUSTOM_ID")
+                                           t))
+                  ;; KEY may be the empty string the the property is
+                  ;; present but has no value
+                  (> (length key) 0)
+                  key)))))
+
 (provide 'bibtex-completion)
 
 ;; Local Variables:

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -225,8 +225,10 @@ reread."
     (helm :sources (list helm-source-bibtex helm-source-fallback-options)
           :full-frame helm-bibtex-full-frame
           :buffer "*helm bibtex*"
-          :preselect  (lambda ()
-                        (and preselect (helm-next-line preselect)))
+          :preselect (lambda ()
+                       (and preselect
+                            (> preselect 0)
+                            (helm-next-line preselect)))
           :candidate-number-limit (max 500 (1+ (or preselect 0)))
           :bibtex-candidates candidates)))
 

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -179,8 +179,7 @@ comes out in the right buffer."
 
 (defvar helm-source-bibtex
   (helm-build-sync-source "BibTeX entries"
-    :init 'bibtex-completion-init
-    :candidates 'bibtex-completion-candidates
+    :candidates 'helm-bibtex-candidates
     :filtered-candidate-transformer 'helm-bibtex-candidates-formatter
     :action (helm-make-actions
              "Open PDF, URL or DOI"       'helm-bibtex-open-any
@@ -215,10 +214,21 @@ reread."
   (interactive "P")
   (when arg
     (bibtex-completion-clear-cache))
-  (helm :sources (list helm-source-bibtex helm-source-fallback-options)
-        :full-frame helm-bibtex-full-frame
-        :buffer "*helm bibtex*"
-        :candidate-number-limit 500))
+  (bibtex-completion-init)
+  (let* ((candidates (bibtex-completion-candidates))
+         (key (bibtex-completion-key-at-point))
+         (preselect (and key
+                         (cl-position-if (lambda (cand)
+                                           (member (cons "=key=" key)
+                                                   (cdr cand)))
+                                         candidates))))
+    (helm :sources (list helm-source-bibtex helm-source-fallback-options)
+          :full-frame helm-bibtex-full-frame
+          :buffer "*helm bibtex*"
+          :preselect  (lambda ()
+                        (and preselect (helm-next-line preselect)))
+          :candidate-number-limit (max 500 (1+ (or preselect 0)))
+          :bibtex-candidates candidates)))
 
 ;;;###autoload
 (defun helm-bibtex-with-local-bibliography (&optional arg)

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -136,10 +136,18 @@ reread."
   (when arg
     (bibtex-completion-clear-cache))
   (bibtex-completion-init)
-  (ivy-read "BibTeX Items: "
-            (bibtex-completion-candidates)
-            :caller 'ivy-bibtex
-            :action ivy-bibtex-default-action))
+  (let* ((candidates (bibtex-completion-candidates))
+         (key (bibtex-completion-key-at-point))
+         (preselect (and key
+                         (cl-position-if (lambda (cand)
+                                           (member (cons "=key=" key)
+                                                   (cdr cand)))
+                                         candidates))))
+    (ivy-read "BibTeX Items: "
+              candidates
+              :preselect preselect
+              :caller 'ivy-bibtex
+              :action ivy-bibtex-default-action)))
 
 ;;;###autoload
 (defun ivy-bibtex-with-local-bibliography (&optional arg)


### PR DESCRIPTION
Re #121 

The core function is `bibtex-completion-key-at-point`, which identifies the bibtex key around point depending on the context. Here is its docstring:

> "Return the key of the BibTeX entry at point. If the current
file is a BibTeX file, return the key of the entry at
point. Otherwise, try to use reftex to check whether point is
at a citation macro, and if so return the key at
point. Otherwise, if the current file is an org-mode file, return
the value of `org-bibtex-key-property' (or
default to \"CUSTOM_ID\"). Otherwise, return nil."

It can certainly be enriched, eg to detect if point is on a crossref field or an org-mode citation link.

Then `helm-bibtex` and `ivy-bibtex` make use of it to preselect the corresponding entry. For `helm-bibtex` this sometimes implies increasing the candidate number limit.