### PR TITLE
ignore reftex errors when finding local bibliography

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1192,7 +1192,7 @@ BibTeX files. If this fails, return
            (list (buffer-file-name)))
       (and (buffer-file-name)
            (require 'reftex-cite nil t)
-           (reftex-get-bibfile-list))
+           (ignore-errors (reftex-get-bibfile-list)))
       bibtex-completion-bibliography))
 
 (provide 'bibtex-completion)


### PR DESCRIPTION
When `bibtex-completion-find-bibliography` resorts to `reftex-get-bibfile-list` if it does not find a bibliography file. Ignoring such errors allows to fall back to the global bibliography.