### PR TITLE
fixes PDF loading issue issue where blank path could block later real path

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -655,14 +655,19 @@ file is specified, or if the specified file does not exist, or if
                          (append
                           (list
                            path
+                           file-name
                            (f-join (f-root) path) ; Mendeley #105
                            (f-join (f-root) path file-name)) ; Mendeley #105
                           (--map (f-join it path)
                                  (-flatten bibtex-completion-library-path)) ; Jabref #100
                           (--map (f-join it path file-name)
                                  (-flatten bibtex-completion-library-path)))) ; Jabref #100
-           for result = (-first 'f-exists? paths)
-           if (not (s-blank-str? result)) collect result)))))))
+           for result = (-first (lambda (path)
+                                  (if (and (not (s-blank-str? path))
+                                           (f-exists? path))
+                                      path nil)) paths)
+           if result collect result)))))))
+
 
 (defun bibtex-completion-find-pdf-in-library (key-or-entry &optional find-additional)
   "Searches the directories in `bibtex-completion-library-path'


### PR DESCRIPTION
I'm using Zotero with the better-biblatex exporter, which apparently represents the PDF files as:

```
file = {/full/path/to/doc1.pdf;/full/path/to/doc2.pdf;/full/path/to/doc3.html}
```

When there's only one PDF this gets caught by [this line](https://github.com/tmalsburg/helm-bibtex/blob/84863a37695b786c6c6980a589f8ea282c385ab2/bibtex-completion.el#L638) and works fine. With multiple PDFs though, the path gets stored in `file-name` and `path` is `""`, and then the first element in `paths` is `""`, which exists so it gets assigned to `result`. Unfortunately it's a blank string so it gets killed. The problem is that there could be a valid path later on in the `paths` list. This PR tweaks the logic a little bit to get the first path that is both non-empty and exists.