### PR TITLE
display ✎ for  entry key with dot ("." )

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -767,7 +767,7 @@ find a PDF file."
                        ;; All notes in one file:
                        (and bibtex-completion-notes-path
                             (f-file? bibtex-completion-notes-path)
-			    (member (regexp-quote entry-key) bibtex-completion-cached-notes-keys)))
+			    (member entry-key bibtex-completion-cached-notes-keys)))
                       (cons (cons "=has-note=" bibtex-completion-notes-symbol) entry)
                     entry))
            ; Remove unwanted fields:


### PR DESCRIPTION
Correctly display pen symbol (✎) when there is dot ("." ) in a entry key ( like "123.456") .
It is not necessary to use function "regexp-quote"  because the function  "member" doesn't use regular expression.
With "regexp-quote" there is no (✎) because "." is  changed to "\\\\." but there is no such change in variable bibtex-completion-cached-notes-keys.