### PR TITLE
Add line to README about how to set up ivy

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,6 +55,12 @@ or
 
 #+BEGIN_SRC emacs-lisp
 (autoload 'ivy-bibtex "ivy-bibtex" "" t)
+;; ivy-bibtex requires ivy's `ivy--regex-ignore-order` regex builder, which 
+;; ignores the order of regexp tokens when searching for matching candidates. 
+;; Add something like this to your init file:
+(setq ivy-re-builders-alist
+      '((ivy-bibtex . ivy--regex-ignore-order)
+        (t . ivy--regex-plus)))
 #+END_SRC
 
 Helm-bibtex and ivy-bibtex depend on a number of packages that will be automatically installed if you use MELPA.


### PR DESCRIPTION
`bibtex-completion-candidates` creates search strings in which bibtex fields are ordered according to their order of appereance in a bibtex file. Unless one is very strict about ordering all entries in exactly the same way, this might lead to variable orderings. This is problematic in light of ivy's default regexp builder which expects all orderings to be the same. This problem can be resolved by using the (slightly slower) `ivy--regex-ignore-order` with ivy-bibtex.

Since ivy-bibtex is barely useable without this configuration, it's not really a matter of configuration but proper installation. As such, I added a line directly underneath `(autoload 'ivy-bibtex "ivy-bibtex" "" t)` in the Installation section.