### PR TITLE
Notes: narrow to the complete template instead of last org-heading

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1329,13 +1329,14 @@ line."
             (goto-char (point-max))
             (save-excursion (insert (s-format bibtex-completion-notes-template-one-file
                                               'bibtex-completion-apa-get-value
-                                              entry))))
-          (when (eq major-mode 'org-mode)
-            (org-narrow-to-subtree)
-            (re-search-backward "^\*+ " nil t)
-            (org-cycle-hide-drawers nil)
-            (goto-char (point-max))
-            (bibtex-completion-notes-mode 1))))))
+                                              entry)))
+            (re-search-forward "^*+ " nil t))
+        (when (eq major-mode 'org-mode)
+          (org-narrow-to-subtree)
+          (re-search-backward "^\*+ " nil t)
+          (org-cycle-hide-drawers nil)
+          (goto-char (point-max))
+          (bibtex-completion-notes-mode 1))))))
 
 (defun bibtex-completion-buffer-visiting (file)
   (or (get-file-buffer file)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1327,9 +1327,9 @@ line."
               (bibtex-completion-notes-mode 1))
                                         ; Create a new entry:
             (goto-char (point-max))
-            (insert (s-format bibtex-completion-notes-template-one-file
-                              'bibtex-completion-apa-get-value
-                              entry)))
+            (save-excursion (insert (s-format bibtex-completion-notes-template-one-file
+                                              'bibtex-completion-apa-get-value
+                                              entry))))
           (when (eq major-mode 'org-mode)
             (org-narrow-to-subtree)
             (re-search-backward "^\*+ " nil t)


### PR DESCRIPTION
Before, a note template consisting of sub-headings would result in
only showing that sub-heading, e.g. using a template like this:

* Author (XXX): Title
** takeaways
** new questions
** additional literature

would only narrow to additional literature.  Now we narrow to the
complete template instead.

A side-effect is that for non-org templates the point is now at the
start of the template instead of the end.