### PR TITLE
allow underscore in citekeys

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1454,7 +1454,11 @@ default to \"CUSTOM_ID\"). Otherwise, return nil."
              (let ((macro (reftex-what-macro 1)))
                (and (stringp (car macro))
                     (string-match "\\`\\\\cite\\|cite\\'" (car macro))
-                    (thing-at-point 'symbol)))))
+                    ;; allow '_' in citekeys
+                    (let ((temp-syn-table (make-syntax-table)))
+                      (modify-syntax-entry ?_ "_" temp-syn-table)
+                      (with-syntax-table temp-syn-table
+                        (thing-at-point 'symbol)))))))
       (and (eq major-mode 'org-mode)
            (let (key)
              (and (setq key (org-entry-get nil


### PR DESCRIPTION
Hi! I don't know if I was doing something wrong or had something misconfigured, but I couldn't get `bibtex-completion-key-at-point` to recognise keys containing `_`. This fixes that, but there might be a better way? Maybe it would be OK to permanently modify the syntax table for `LaTeX-mode` instead.