### PR TITLE
Change buffer selection method when exiting notes

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1291,7 +1291,7 @@ line."
   (setq-local
    header-line-format nil)
   (save-buffer)
-  (let ((window (get-buffer-window (file-name-nondirectory bibtex-completion-notes-path))))
+  (let ((window (get-buffer-window (get-file-buffer bibtex-completion-notes-path))))
     (if (and window (not (one-window-p window)))
         (delete-window window)
       (switch-to-buffer (other-buffer)))))


### PR DESCRIPTION
Sometime I have multiple "notes.org" files open and the original method for selecting window will fail.

First time opening a pull request and pretty new to elisp. Hope this can help.