### PR TITLE
remove formatting macros from plain text references

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1120,13 +1120,16 @@ guidelines.  Return DEFAULT if FIELD is not present in ENTRY."
             ("title" (replace-regexp-in-string ; remove braces
                       "[{}]"
                       ""
-                      (replace-regexp-in-string ; upcase initial letter
-                       "^[[:alpha:]]"
-                       'upcase
-                       (replace-regexp-in-string ; preserve stuff in braces from being downcased
-                        "\\(^[^{]*{\\)\\|\\(}[^{]*{\\)\\|\\(}.*$\\)\\|\\(^[^{}]*$\\)"
-                        (lambda (x) (downcase (s-replace "\\" "\\\\" x)))
-                        value))))
+                      (replace-regexp-in-string ; remove macros
+                       "\\\\[[:alpha:]]+{"
+                       ""
+                       (replace-regexp-in-string ; upcase initial letter
+                        "^[[:alpha:]]"
+                        'upcase
+                        (replace-regexp-in-string ; preserve stuff in braces from being downcased
+                         "\\(^[^{]*{\\)\\|\\(}[^{]*{\\)\\|\\(}.*$\\)\\|\\(^[^{}]*$\\)"
+                         (lambda (x) (downcase (s-replace "\\" "\\\\" x)))
+                         value)))))
             ("booktitle" value)
             ;; Maintain the punctuation and capitalization that is used by
             ;; the journal in its title.


### PR DESCRIPTION
Addressing issue #295 

Added an additional replace-regexps-in-string clause to
bibtex-completion-apa-get-value: removes the pattern "\\MACRO{"" from
titles, where MACRO is arbitrary letters. This eliminates "\\emph{", and
any other macro forms that might be used to format text in a title.

Tested on examples from my .bib database - doesn't appear to break anything for me.