### PR TITLE
Enable org-capture template expansions for file notes

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1335,10 +1335,13 @@ line."
                                (s-concat key bibtex-completion-notes-extension))))
             (find-file path)
             (unless (f-exists? path)
+              ;; First expend bibtex variables, then org-capture template
               (insert (org-capture-fill-template
-                       (s-format bibtex-completion-notes-template-multiple-files
-                                 'bibtex-completion-apa-get-value
-                                 entry)))))
+                       (concat (s-format bibtex-completion-notes-template-multiple-files
+                                         'bibtex-completion-apa-get-value
+                                         entry)
+                               "%s")))
+              (delete-region (point-max) (- (point-max) 3))))
                                         ; One file for all notes:
         (unless (and buffer-file-name
                      (f-same? bibtex-completion-notes-path buffer-file-name))

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1368,7 +1368,17 @@ line."
           (re-search-backward "^\*+ " nil t)
           (org-cycle-hide-drawers nil)
           (goto-char (point-max))
-          (bibtex-completion-notes-mode 1))))))
+          (bibtex-completion-notes-mode 1))
+        ;; Delete the final newline inserted by ‘org-capture-fill-template’
+        (delete-char -1)
+        ;; Move point to ‘%?’ if it’s included in the pattern
+        (when (save-excursion
+                (progn (goto-char (point-min))
+                       (re-search-forward "%\\?" nil t)))
+          (let ((beginning (match-beginning 0))
+                (end (match-end 0)))
+            (delete-region beginning end)
+            (goto-char beginning)))))))
 
 (defun bibtex-completion-buffer-visiting (file)
   (or (get-file-buffer file)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1358,9 +1358,10 @@ line."
               (bibtex-completion-notes-mode 1))
                                         ; Create a new entry:
             (goto-char (point-max))
-            (save-excursion (insert (s-format bibtex-completion-notes-template-one-file
-                                              'bibtex-completion-apa-get-value
-                                              entry)))
+            (save-excursion (insert (org-capture-fill-template
+                                     (s-format bibtex-completion-notes-template-one-file
+                                               'bibtex-completion-apa-get-value
+                                               entry))))
             (re-search-forward "^*+ " nil t))
         (when (eq major-mode 'org-mode)
           (org-narrow-to-subtree)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1330,14 +1330,18 @@ according to `org-capture-templates'."
   (let ((bibtex-exp (s-format template
                               'bibtex-completion-apa-get-value
                               entry)))
-    (->> bibtex-exp
+    (--> bibtex-exp
          ;; Escape newlines to prevent `org-capture-fill-template' from
          ;; gobbling them
-         (replace-regexp-in-string "\n" "\\\\n")
-         (org-capture-fill-template)
+         (replace-regexp-in-string "\n\\|
+" "\\\\n" it)
+         (org-capture-fill-template it)
          ;; Restore newlines
          (replace-regexp-in-string "\\\\n" "
-"))))
+" it)
+         ;; Delete trailing newline inserted by `org-capture-fill-template'
+         (substring it 0 -1)
+         )))
 
 (defun bibtex-completion-edit-notes (keys)
   "Open the notes associated with the selected entries using `find-file'."
@@ -1356,9 +1360,7 @@ according to `org-capture-templates'."
               ;; First expend bibtex variables, then org-capture template
               (insert (bibtex-completion-fill-template
                        entry
-                       bibtex-completion-notes-template-multiple-files))
-              ;; Delete the final newline inserted by `org-capture-fill-template'
-              (delete-char -1)))
+                       bibtex-completion-notes-template-multiple-files))))
                                         ; One file for all notes:
         (unless (and buffer-file-name
                      (f-same? bibtex-completion-notes-path buffer-file-name))

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1336,12 +1336,15 @@ line."
             (find-file path)
             (unless (f-exists? path)
               ;; First expend bibtex variables, then org-capture template
-              (insert (org-capture-fill-template
-                       (concat (s-format bibtex-completion-notes-template-multiple-files
-                                         'bibtex-completion-apa-get-value
-                                         entry)
-                               "%?")))
-              (delete-region (point-max) (- (point-max) 3))))
+              (insert (replace-regexp-in-string
+                       "\\\\n" "
+"
+                       (org-capture-fill-template
+                        (s-format bibtex-completion-notes-template-multiple-files
+                                  'bibtex-completion-apa-get-value
+                                  entry))))
+              ;; Delete the final newline inserted by ‘org-capture-fill-template’
+              (delete-char -1)))
                                         ; One file for all notes:
         (unless (and buffer-file-name
                      (f-same? bibtex-completion-notes-path buffer-file-name))
@@ -1358,10 +1361,13 @@ line."
               (bibtex-completion-notes-mode 1))
                                         ; Create a new entry:
             (goto-char (point-max))
-            (save-excursion (insert (org-capture-fill-template
-                                     (s-format bibtex-completion-notes-template-one-file
-                                               'bibtex-completion-apa-get-value
-                                               entry))))
+            (save-excursion (insert (replace-regexp-in-string
+                                     "\\\\n" "
+"
+                                     (org-capture-fill-template
+                                      (s-format bibtex-completion-notes-template-one-file
+                                                'bibtex-completion-apa-get-value
+                                                entry)))))
             (re-search-forward "^*+ " nil t))
         (when (eq major-mode 'org-mode)
           (org-narrow-to-subtree)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1330,17 +1330,18 @@ according to `org-capture-templates'."
   (let ((bibtex-exp (s-format template
                               'bibtex-completion-apa-get-value
                               entry)))
-    (--> bibtex-exp
-         ;; Escape newlines to prevent `org-capture-fill-template' from
-         ;; gobbling them
-         (replace-regexp-in-string "\n\\|
-" "\\\\n" it)
-         (org-capture-fill-template it)
-         ;; Restore newlines
-         (replace-regexp-in-string "\\\\n" "
-" it)
-         ;; Delete trailing newline inserted by `org-capture-fill-template'
-         (substring it 0 -1))))
+    ;; Delete trailing newline inserted by `org-capture-fill-template'
+    (substring
+     (->> bibtex-exp
+          ;; Escape newlines to prevent `org-capture-fill-template' from
+          ;; gobbling them
+          (replace-regexp-in-string "\n\\|
+" "\\\\n")
+          (org-capture-fill-template)
+          ;; Restore newlines
+          (replace-regexp-in-string "\\\\n" "
+"))
+     0 -1)))
 
 (defun bibtex-completion-edit-notes (keys)
   "Open the notes associated with the selected entries using `find-file'."

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1335,12 +1335,10 @@ according to `org-capture-templates'."
      (->> bibtex-exp
           ;; Escape newlines to prevent `org-capture-fill-template' from
           ;; gobbling them
-          (replace-regexp-in-string "\n\\|
-" "\\\\n")
+          (replace-regexp-in-string "\n" "\\\\n")
           (org-capture-fill-template)
           ;; Restore newlines
-          (replace-regexp-in-string "\\\\n" "
-"))
+          (replace-regexp-in-string "\\\\n" "\n"))
      0 -1)))
 
 (defun bibtex-completion-edit-notes (keys)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1341,7 +1341,15 @@ according to `org-capture-templates'."
           (replace-regexp-in-string "\\\\n" "\n"))
      0 -1)))
 
-(defun bibtex-completion-edit-notes (keys)
+(defcustom bibtex-completion-edit-notes-fn
+  #'bibtex-completion-edit-notes-default
+  "Function to use to edit notes.
+The function should accept one argument, a list of BibTeX
+entry-keys."
+  :group 'helm-bibtex
+  :type 'function)
+
+(defun bibtex-completion-edit-notes-default (keys)
   "Open the notes associated with the selected entries using `find-file'."
   (dolist (key keys)
     (let* ((entry (bibtex-completion-get-entry key))
@@ -1393,6 +1401,10 @@ according to `org-capture-templates'."
                 (end (match-end 0)))
             (delete-region beginning end)
             (goto-char beginning)))))))
+
+(defun bibtex-completion-edit-notes (keys)
+  "Open the notes associated with `bibtex-completion-edit-notes-fn'."
+  (funcall bibtex-completion-edit-notes-fn keys))
 
 (defun bibtex-completion-buffer-visiting (file)
   (or (get-file-buffer file)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1340,7 +1340,7 @@ line."
                        (concat (s-format bibtex-completion-notes-template-multiple-files
                                          'bibtex-completion-apa-get-value
                                          entry)
-                               "%s")))
+                               "%?")))
               (delete-region (point-max) (- (point-max) 3))))
                                         ; One file for all notes:
         (unless (and buffer-file-name

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1376,11 +1376,11 @@ according to `org-capture-templates'."
               (org-cycle-hide-drawers nil)
               (bibtex-completion-notes-mode 1))
                                         ; Create a new entry:
-            (goto-char (point-max))
-            (save-excursion (insert (bibtex-completion-fill-template
-                                     entry
-                                     bibtex-completion-notes-template-one-file)))
-            (re-search-forward "^*+ " nil t))
+          (goto-char (point-max))
+          (save-excursion (insert (bibtex-completion-fill-template
+                                   entry
+                                   bibtex-completion-notes-template-one-file)))
+          (re-search-forward "^*+ " nil t))
         (when (eq major-mode 'org-mode)
           (org-narrow-to-subtree)
           (re-search-backward "^\*+ " nil t)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1335,9 +1335,10 @@ line."
                                (s-concat key bibtex-completion-notes-extension))))
             (find-file path)
             (unless (f-exists? path)
-              (insert (s-format bibtex-completion-notes-template-multiple-files
-                                'bibtex-completion-apa-get-value
-                                entry))))
+              (insert (org-capture-fill-template
+                       (s-format bibtex-completion-notes-template-multiple-files
+                                 'bibtex-completion-apa-get-value
+                                 entry)))))
                                         ; One file for all notes:
         (unless (and buffer-file-name
                      (f-same? bibtex-completion-notes-path buffer-file-name))

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1340,8 +1340,7 @@ according to `org-capture-templates'."
          (replace-regexp-in-string "\\\\n" "
 " it)
          ;; Delete trailing newline inserted by `org-capture-fill-template'
-         (substring it 0 -1)
-         )))
+         (substring it 0 -1))))
 
 (defun bibtex-completion-edit-notes (keys)
   "Open the notes associated with the selected entries using `find-file'."


### PR DESCRIPTION
Hello,

I wanted to include timestamps in the header of my file-notes, but I realised that `bibtex-completion-notes-template-multiple-files` didn't handle `org-capture` template expansions.  Since I don't think there is any drawback to it, I figured we could add it in `master`.

Thanks for your work on `helm-bibtex`.  I've been running it for a few years, and it's been stellar.

HTH.