### PR TITLE
Require org-capture

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -40,6 +40,7 @@
 (require 'f)
 (require 'biblio)
 (require 'filenotify)
+(require 'org-capture)
 
 ;; Silence byte-compiler
 (declare-function reftex-what-macro "reftex-parse")


### PR DESCRIPTION
Since we’re now using `org-capture-fill-template`, we need to require `org-capture`.

Problem was brought up in #309.