### PR TITLE
Implement commands to only present candidates with notes

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -551,11 +551,10 @@ fields listed above) as an alist."
       for file in files
       append (cddr (assoc file bibtex-completion-cache))))))
 
-(defun bibtex-completion-candidates-with-notes ()
-  "Read the BibTeX files and return a list of candidates with notes.
+(defun bibtex-completion-candidates-with-notes (candidates)
+  "Return a filtered list of CANDIDATES without notes.
 See `bibtex-completion-candidates' for details."
-  (let ((candidates (bibtex-completion-candidates))
-        candidates-with-notes)
+  (let (candidates-with-notes)
     (dolist (candidate candidates candidates-with-notes)
       (when (assoc "=has-note=" candidate)
         (setq candidates-with-notes

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -562,25 +562,6 @@ See `bibtex-completion-candidates' for details."
               ;; nconc instead of push to avoid reversing
               (nconc candidates-with-notes (list candidate)))))))
 
-(defun bibtex-completion-get-candidates (&optional candidates)
-  "Retrieve the candidates to be used by the completion engine.
-
-By default, the candidates are retrieved with
-`bibtex-completion-candidates'.  If CANDIDATES is non-nil, it can
-either be a list of candidates as formatted by
-`bibtex-completion-candidates', or a function without any
-argument that returns such a list.
-
-See `bibtex-completion-candidates' for details."
-  (pcase candidates
-    ;; Default to `bibtex-completion-candidates'
-    ('() (bibtex-completion-candidates))
-    ((pred functionp) (funcall candidates))
-    ((pred listp) candidates)
-    (wrong-type (signal 'wrong-type-argument
-                        `((functionp listp)
-                          ,wrong-type)))))
-
 (defun bibtex-completion-resolve-crossrefs (files reparsed-files)
   "Expand all entries with fields from cross-referenced entries in FILES, assuming that only those files in REPARSED-FILES were reparsed whereas the other files in FILES were up-to-date."
   (cl-loop

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -551,16 +551,6 @@ fields listed above) as an alist."
       for file in files
       append (cddr (assoc file bibtex-completion-cache))))))
 
-(defun bibtex-completion-candidates-with-notes (candidates)
-  "Return a filtered list of CANDIDATES without notes.
-See `bibtex-completion-candidates' for details."
-  (let (candidates-with-notes)
-    (dolist (candidate candidates candidates-with-notes)
-      (when (assoc "=has-note=" candidate)
-        (setq candidates-with-notes
-              ;; nconc instead of push to avoid reversing
-              (nconc candidates-with-notes (list candidate)))))))
-
 (defun bibtex-completion-resolve-crossrefs (files reparsed-files)
   "Expand all entries with fields from cross-referenced entries in FILES, assuming that only those files in REPARSED-FILES were reparsed whereas the other files in FILES were up-to-date."
   (cl-loop

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -551,6 +551,17 @@ fields listed above) as an alist."
       for file in files
       append (cddr (assoc file bibtex-completion-cache))))))
 
+(defun bibtex-completion-candidates-with-notes ()
+  "Read the BibTeX files and return a list of candidates with notes.
+See `bibtex-completion-candidates' for details."
+  (let ((candidates (bibtex-completion-candidates))
+        candidates-with-notes)
+    (dolist (candidate candidates candidates-with-notes)
+      (when (assoc "=has-note=" candidate)
+        (setq candidates-with-notes
+              ;; nconc instead of push to avoid reversing
+              (nconc candidates-with-notes (list candidate)))))))
+
 (defun bibtex-completion-resolve-crossrefs (files reparsed-files)
   "Expand all entries with fields from cross-referenced entries in FILES, assuming that only those files in REPARSED-FILES were reparsed whereas the other files in FILES were up-to-date."
   (cl-loop

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -562,6 +562,25 @@ See `bibtex-completion-candidates' for details."
               ;; nconc instead of push to avoid reversing
               (nconc candidates-with-notes (list candidate)))))))
 
+(defun bibtex-completion-get-candidates (&optional candidates)
+  "Retrieve the candidates to be used by the completion engine.
+
+By default, the candidates are retrieved with
+`bibtex-completion-candidates'.  If CANDIDATES is non-nil, it can
+either be a list of candidates as formatted by
+`bibtex-completion-candidates', or a function without any
+argument that returns such a list.
+
+See `bibtex-completion-candidates' for details."
+  (pcase candidates
+    ;; Default to `bibtex-completion-candidates'
+    ('() (bibtex-completion-candidates))
+    ((pred functionp) (funcall candidates))
+    ((pred listp) candidates)
+    (wrong-type (signal 'wrong-type-argument
+                        `((functionp listp)
+                          ,wrong-type)))))
+
 (defun bibtex-completion-resolve-crossrefs (files reparsed-files)
   "Expand all entries with fields from cross-referenced entries in FILES, assuming that only those files in REPARSED-FILES were reparsed whereas the other files in FILES were up-to-date."
   (cl-loop

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -262,18 +262,6 @@ reread."
   (cl-letf* ((candidates (bibtex-completion-candidates))
              ((symbol-function 'bibtex-completion-candidates)
               (lambda ()
-                (bibtex-completion-candidates-with-notes candidates))))
-    (helm-bibtex arg)))
-
-(defun helm-bibtex-with-notes (&optional arg)
-  "Search BibTeX entries with notes.
-
-With a prefix ARG the cache is invalidated and the bibliography
-reread."
-  (interactive "P")
-  (cl-letf* ((candidates (bibtex-completion-candidates))
-             ((symbol-function 'bibtex-completion-candidates)
-              (lambda ()
                 (seq-filter
                  (lambda (entry) (assoc "=has-note=" entry))
                  candidates))))

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -265,6 +265,20 @@ reread."
                 (bibtex-completion-candidates-with-notes candidates))))
     (helm-bibtex arg)))
 
+(defun helm-bibtex-with-notes (&optional arg)
+  "Search BibTeX entries with notes.
+
+With a prefix ARG the cache is invalidated and the bibliography
+reread."
+  (interactive "P")
+  (cl-letf* ((candidates (bibtex-completion-candidates))
+             ((symbol-function 'bibtex-completion-candidates)
+              (lambda ()
+                (seq-filter
+                 (lambda (entry) (assoc "=has-note=" entry))
+                 candidates))))
+    (helm-bibtex)))
+
 (provide 'helm-bibtex)
 
 ;; Local Variables:

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -204,7 +204,7 @@ comes out in the right buffer."
 ;; Helm-bibtex command:
 
 ;;;###autoload
-(defun helm-bibtex (&optional arg local-bib input candidates)
+(defun helm-bibtex (&optional arg local-bib input)
   "Search BibTeX entries.
 
 With a prefix ARG, the cache is invalidated and the bibliography
@@ -216,16 +216,12 @@ from the local bibliography.  This is set internally by
 
 If INPUT is non-nil and a string, that value is going to be used
 as a predefined search term.  Can be used to define functions for
-frequent searches (e.g. your own publications).
-
-If CANDIDATES is non-nil, it can either be a list of candidates
-as formatted by `bibtex-completion-candidates', or a function
-without any argument that returns such a list."
+frequent searches (e.g. your own publications)."
   (interactive "P")
   (when arg
     (bibtex-completion-clear-cache))
   (bibtex-completion-init)
-  (let* ((candidates (bibtex-completion-get-candidates candidates))
+  (let* ((candidates (bibtex-completion-candidates))
          (key (bibtex-completion-key-at-point))
          (preselect (and key
                          (cl-position-if (lambda (cand)

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -204,7 +204,7 @@ comes out in the right buffer."
 ;; Helm-bibtex command:
 
 ;;;###autoload
-(defun helm-bibtex (&optional arg local-bib input)
+(defun helm-bibtex (&optional arg local-bib input candidates)
   "Search BibTeX entries.
 
 With a prefix ARG, the cache is invalidated and the bibliography
@@ -216,12 +216,16 @@ from the local bibliography.  This is set internally by
 
 If INPUT is non-nil and a string, that value is going to be used
 as a predefined search term.  Can be used to define functions for
-frequent searches (e.g. your own publications)."
+frequent searches (e.g. your own publications).
+
+If CANDIDATES is non-nil, it can either be a list of candidates
+as formatted by `bibtex-completion-candidates', or a function
+without any argument that returns such a list."
   (interactive "P")
   (when arg
     (bibtex-completion-clear-cache))
   (bibtex-completion-init)
-  (let* ((candidates (bibtex-completion-candidates))
+  (let* ((candidates (bibtex-completion-get-candidates candidates))
          (key (bibtex-completion-key-at-point))
          (preselect (and key
                          (cl-position-if (lambda (cand)

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -256,16 +256,6 @@ reread."
                                              bibtex-completion-bibliography)))
     (helm-bibtex arg local-bib)))
 
-;;;###autoload
-(defun helm-bibtex-with-notes (&optional arg)
-  "Search BibTeX entries with notes.
-
-With a prefix ARG the cache is invalidated and the bibliography
-reread."
-  (interactive "P")
-  (let ((candidates (bibtex-completion-candidates-with-notes)))
-    (helm-bibtex arg nil nil candidates)))
-
 (provide 'helm-bibtex)
 
 ;; Local Variables:

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -252,6 +252,19 @@ reread."
                                              bibtex-completion-bibliography)))
     (helm-bibtex arg local-bib)))
 
+;;;###autoload
+(defun helm-bibtex-with-notes (&optional arg)
+  "Search BibTeX entries with notes.
+
+With a prefix ARG the cache is invalidated and the bibliography
+reread."
+  (interactive "P")
+  (cl-letf* ((candidates (bibtex-completion-candidates))
+             ((symbol-function 'bibtex-completion-candidates)
+              (lambda ()
+                (bibtex-completion-candidates-with-notes candidates))))
+    (helm-bibtex arg)))
+
 (provide 'helm-bibtex)
 
 ;; Local Variables:

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -256,6 +256,16 @@ reread."
                                              bibtex-completion-bibliography)))
     (helm-bibtex arg local-bib)))
 
+;;;###autoload
+(defun helm-bibtex-with-notes (&optional arg)
+  "Search BibTeX entries with notes.
+
+With a prefix ARG the cache is invalidated and the bibliography
+reread."
+  (interactive "P")
+  (let ((candidates (bibtex-completion-candidates-with-notes)))
+    (helm-bibtex arg nil nil candidates)))
+
 (provide 'helm-bibtex)
 
 ;; Local Variables:

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -170,7 +170,9 @@ reread."
   (cl-letf* ((candidates (bibtex-completion-candidates))
              ((symbol-function 'bibtex-completion-candidates)
               (lambda ()
-                (bibtex-completion-candidates-with-notes candidates))))
+                (seq-filter
+                 (lambda (entry) (assoc "=has-note=" entry))
+                 candidates))))
     (ivy-bibtex arg)))
 
 (ivy-set-display-transformer

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -164,6 +164,16 @@ reread."
                                              bibtex-completion-bibliography)))
     (ivy-bibtex arg local-bib)))
 
+;;;###autoload
+(defun ivy-bibtex-with-notes (&optional arg)
+  "Search BibTeX entries with notes.
+
+With a prefix ARG the cache is invalidated and the bibliography
+reread."
+  (interactive "P")
+  (let ((candidates (bibtex-completion-candidates-with-notes)))
+    (ivy-bibtex arg nil candidates)))
+
 (ivy-set-display-transformer
  'ivy-bibtex
  'ivy-bibtex-display-transformer)

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -122,7 +122,7 @@ This is meant to be used as an action in `ivy-read`, with
             :action (lambda (candidate) (bibtex-completion-fallback-action (cdr candidate) search-expression))))
 
 ;;;###autoload
-(defun ivy-bibtex (&optional arg local-bib candidates)
+(defun ivy-bibtex (&optional arg local-bib)
   "Search BibTeX entries using ivy.
 
 With a prefix ARG the cache is invalidated and the bibliography
@@ -130,16 +130,12 @@ reread.
 
 If LOCAL-BIB is non-nil, display that the BibTeX entries are read
 from the local bibliography.  This is set internally by
-`ivy-bibtex-with-local-bibliography'.
-
-If CANDIDATES is non-nil, it can either be a list of candidates
-as formatted by `bibtex-completion-candidates', or a function
-without any argument that returns such a list."
+`ivy-bibtex-with-local-bibliography'."
   (interactive "P")
   (when arg
     (bibtex-completion-clear-cache))
   (bibtex-completion-init)
-  (let* ((candidates (bibtex-completion-get-candidates candidates))
+  (let* ((candidates (bibtex-completion-candidates))
          (key (bibtex-completion-key-at-point))
          (preselect (and key
                          (cl-position-if (lambda (cand)

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -160,6 +160,19 @@ reread."
                                              bibtex-completion-bibliography)))
     (ivy-bibtex arg local-bib)))
 
+;;;###autoload
+(defun ivy-bibtex-with-notes (&optional arg)
+  "Search BibTeX entries with notes.
+
+With a prefix ARG the cache is invalidated and the bibliography
+reread."
+  (interactive "P")
+  (cl-letf* ((candidates (bibtex-completion-candidates))
+             ((symbol-function 'bibtex-completion-candidates)
+              (lambda ()
+                (bibtex-completion-candidates-with-notes candidates))))
+    (ivy-bibtex arg)))
+
 (ivy-set-display-transformer
  'ivy-bibtex
  'ivy-bibtex-display-transformer)

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -122,7 +122,7 @@ This is meant to be used as an action in `ivy-read`, with
             :action (lambda (candidate) (bibtex-completion-fallback-action (cdr candidate) search-expression))))
 
 ;;;###autoload
-(defun ivy-bibtex (&optional arg local-bib)
+(defun ivy-bibtex (&optional arg local-bib candidates)
   "Search BibTeX entries using ivy.
 
 With a prefix ARG the cache is invalidated and the bibliography
@@ -130,12 +130,16 @@ reread.
 
 If LOCAL-BIB is non-nil, display that the BibTeX entries are read
 from the local bibliography.  This is set internally by
-`ivy-bibtex-with-local-bibliography'."
+`ivy-bibtex-with-local-bibliography'.
+
+If CANDIDATES is non-nil, it can either be a list of candidates
+as formatted by `bibtex-completion-candidates', or a function
+without any argument that returns such a list."
   (interactive "P")
   (when arg
     (bibtex-completion-clear-cache))
   (bibtex-completion-init)
-  (let* ((candidates (bibtex-completion-candidates))
+  (let* ((candidates (bibtex-completion-get-candidates candidates))
          (key (bibtex-completion-key-at-point))
          (preselect (and key
                          (cl-position-if (lambda (cand)

--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -164,16 +164,6 @@ reread."
                                              bibtex-completion-bibliography)))
     (ivy-bibtex arg local-bib)))
 
-;;;###autoload
-(defun ivy-bibtex-with-notes (&optional arg)
-  "Search BibTeX entries with notes.
-
-With a prefix ARG the cache is invalidated and the bibliography
-reread."
-  (interactive "P")
-  (let ((candidates (bibtex-completion-candidates-with-notes)))
-    (ivy-bibtex arg nil candidates)))
-
 (ivy-set-display-transformer
  'ivy-bibtex
  'ivy-bibtex-display-transformer)


### PR DESCRIPTION
New commands:
- `helm-bibtex-with-notes` & `ivy-bibtex-with-notes` to only present candidates with notes.

I've modularised the code so that it can easily be expanded upon.  Rationale behind it was that I wanted a better way to access my Org-roam notes, and I figured this could be useful upstream.  Note that plays nicely with `bibtex-completion-find-note-functions`, so you could easily override its global value in a `let`-form to filter out items with a function.