### PR TITLE
Prevent error on nil with author-abbrev

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1139,14 +1139,14 @@ The format depends on
   "Return FIELD or ENTRY formatted following the APA guidelines.
 Return DEFAULT if FIELD is not present in ENTRY."
   ;; Virtual fields:
-  (cond
-    ((string= field "author-or-editor")
+  (pcase field
+    ("author-or-editor"
      (let ((value (bibtex-completion-get-value "author" entry)))
        (if value
            (bibtex-completion-apa-format-authors value)
          (bibtex-completion-apa-format-editors
           (bibtex-completion-get-value "editor" entry)))))
-    ((string= field "author-abbrev")
+    ("author-abbrev"
      (when-let ((value (bibtex-completion-get-value "author" entry)))
        (bibtex-completion-apa-format-authors-abbrev value)))
     (t

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1141,11 +1141,10 @@ Return DEFAULT if FIELD is not present in ENTRY."
   ;; Virtual fields:
   (pcase field
     ("author-or-editor"
-     (let ((value (bibtex-completion-get-value "author" entry)))
-       (if value
-           (bibtex-completion-apa-format-authors value)
-         (bibtex-completion-apa-format-editors
-          (bibtex-completion-get-value "editor" entry)))))
+     (if-let ((value (bibtex-completion-get-value "author" entry)))
+         (bibtex-completion-apa-format-authors value)
+       (bibtex-completion-apa-format-editors
+        (bibtex-completion-get-value "editor" entry))))
     ("author-abbrev"
      (when-let ((value (bibtex-completion-get-value "author" entry)))
        (bibtex-completion-apa-format-authors-abbrev value)))

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1147,7 +1147,7 @@ Return DEFAULT if FIELD is not present in ENTRY."
          (bibtex-completion-apa-format-editors
           (bibtex-completion-get-value "editor" entry)))))
     ((string= field "author-abbrev")
-     (let ((value (bibtex-completion-get-value "author" entry)))
+     (when-let ((value (bibtex-completion-get-value "author" entry)))
        (bibtex-completion-apa-format-authors-abbrev value)))
     (t
      ;; Real fields:


### PR DESCRIPTION
Do not run `bibtex-completion-apa-format-authors-abbrev` is there is no author
on the entry.

-----

I've encountered the problem whilst testing zaeph/org-roam-bibtex/issues/20.

A better fix might be to implement an expansion for `author-or-editor-abbrev`.  I'm gonna try it now, and probably refactor the cond-check with `pcase`.