### PR TITLE
Use _ instead of t with s-join

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1177,7 +1177,7 @@ Return DEFAULT if FIELD is not present in ENTRY."
              ("booktitle" value)
              ;; Maintain the punctuation and capitalization that is used by
              ;; the journal in its title.
-             ("pages" (s-join "–" (s-split "[^0-9]+" value t)))
+             ("pages" (s-join "–" (s-split "[^0-9]+" value _)))
              ("doi" (s-concat " http://dx.doi.org/" value))
              ("year" (or value
                          (car (split-string (bibtex-completion-get-value "date" entry "") "-"))))


### PR DESCRIPTION
Got a warning that it was deprecated when loading bibtex-completion.  I don’t
use s-join too much, so you might want to verify that everything works as
expected.