### PR TITLE
Fix entries overflowing if they include wide characters

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -417,7 +417,7 @@ Also sets `bibtex-completion-display-formats-internal'."
                   (let* ((format-string (cdr format))
                          (fields-width 0)
                          (string-width
-                          (length
+                          (string-width
                            (s-format format-string
                                      (lambda (field)
                                        (setq fields-width


### PR DESCRIPTION
Using eg. "${title:*}" in `bibtex-completion-display-formats` should truncate that field to the remaining window width, but previously that calculation fails to account for characters wider than one column, like CJK characters or tabstop.

This PR fixes that by using `string-width` (added in Emacs 20) instead of `length` to determine the displayed width of the string.

Demonstration:

```elisp
(setq bibtex-completion-display-formats
  '((t . "${year:4}\t${=has-pdf=:1}${=has-note=:1} ${=type=:10}\t${author:20}\t${title:*}\t${keywords:20}"))
```

Before (note how entries are wrapping because the remaining window width has been overestimated):

![before](https://user-images.githubusercontent.com/11722318/91797265-19f7b800-ec5d-11ea-8560-ed7d37874715.png)

Fixed:

![fixed](https://user-images.githubusercontent.com/11722318/91797270-1d8b3f00-ec5d-11ea-93a8-f66419205935.png)
