### PR TITLE
Add citation format for sphinxcontrib-bibtex

### DIFF
--- a/README.org
+++ b/README.org
@@ -266,6 +266,8 @@ Bibtex-completion creates citations based on the major mode in which the citatio
 - org-mode :: insert link for opening the entry in Ebib
 - latex-mode :: insert LaTeX citation command
 - markdown-mode :: insert Pandoc citation macro
+- python-mode :: insert sphinxcontrib-bibtex citation role
+- rst-mode :: insert sphinxcontrib-bibtex citation role
 - other modes :: insert plain BibTeX key
 
 The list of modes can be extended and the citation functions can be changed using the customization variable ~bibtex-completion-format-citation-functions~.  For example, people who don't use Ebib might prefer links to the PDFs instead of Ebib-links in org mode files:

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -113,6 +113,8 @@ This should be a single character."
   '((org-mode      . bibtex-completion-format-citation-ebib)
     (latex-mode    . bibtex-completion-format-citation-cite)
     (markdown-mode . bibtex-completion-format-citation-pandoc-citeproc)
+    (python-mode   . bibtex-completion-format-citation-sphinxcontrib-bibtex)
+    (rst-mode      . bibtex-completion-format-citation-sphinxcontrib-bibtex)
     (default       . bibtex-completion-format-citation-default))
   "The functions used for formatting citations.
 The publication can be cited, for example, as \cite{key} or
@@ -1029,6 +1031,10 @@ only adds KEYS to it."
   "Format ebib references for keys in KEYS."
   (s-join ", "
           (--map (format "ebib:%s" it) keys)))
+
+(defun bibtex-completion-format-citation-sphinxcontrib-bibtex (keys)
+  "Format sphinxcontrib-bibtex references for keys in KEYS."
+  (format ":cite:`%s`" (s-join "," keys)))
 
 (defun bibtex-completion-format-citation-org-link-to-PDF (keys)
   "Format org-links to PDFs associated with entries in KEYS.


### PR DESCRIPTION
Citation format for [Sphinx](https://www.sphinx-doc.org/en/master/) documentation using [sphinxcontrib-bibtex](https://github.com/mcmtroffaes/sphinxcontrib-bibtex/). Used when in `python-mode` (when writing docstrings) or `rst-mode`(when directly working on the [rst-files](https://docutils.readthedocs.io/en/sphinx-docs/user/rst/quickstart.html) Sphinx creates documentation out of).