### PR TITLE
Better Support to Calibre bib

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -706,7 +706,7 @@ does not exist, or if `bibtex-completion-pdf-field' is nil."
        ((f-file? value) (list value))   ; A bare full path was found.
        ((-any 'f-file? (--map (f-join it (f-filename value)) (-flatten bibtex-completion-library-path))) (-filter 'f-file? (--map (f-join it (f-filename value)) (-flatten bibtex-completion-library-path))))
        (t                               ; Zotero/Mendeley/JabRef format:
-        (let ((value (replace-regexp-in-string "\\([^\\]\\);" "\\1\^^" value)))
+        (let ((value (replace-regexp-in-string "\\([^\\]\\)[;,]" "\\1\^^" value)))
           (cl-loop  ; Looping over the files:
            for record in (s-split "\^^" value)
                                         ; Replace unescaped colons by field separator:

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1288,7 +1288,9 @@ Surrounding curly braces are stripped."
         (replace-regexp-in-string
          "\\(^[[:space:]]*[\"{][[:space:]]*\\)\\|\\([[:space:]]*[\"}][[:space:]]*$\\)"
          ""
-         (s-collapse-whitespace value))
+         (if (equal bibtex-completion-pdf-field field)
+             value
+           (s-collapse-whitespace value)))
       default)))
 
 (defun bibtex-completion-insert-key (keys)


### PR DESCRIPTION
There're some special characters in calibre bib:

1. multiple files are separated by `,` instead of `;` in `file` field
2. file path often contains multiple spaces

So I make some minor changes on  `bibtex-completion-find-pdf-in-field` and `bibtex-completion-get-value` to work better with bib files exported by calibre
