### PR TITLE
Make bibtex-completion (more) interactive

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -68,7 +68,7 @@
     (define-key map (kbd "r") 'bibtex-completion-insert-reference)
     (define-key map (kbd "k") 'bibtex-completion-insert-key)
     (define-key map (kbd "b") 'bibtex-completion-insert-bibtex)
-    (define-key map (kbd "a") 'bibtex-completion-add-PDF-attachment)
+    (define-key map (kbd "a") 'bibtex-completion-add-pdf-attachment)
     (define-key map (kbd "e") 'bibtex-completion-edit-notes)
     (define-key map (kbd "s") 'bibtex-completion-show-entry)
     (define-key map (kbd "l") 'bibtex-completion-add-pdf-to-library)
@@ -1379,9 +1379,15 @@ Self-contained means that cross-referenced entries are merged."
              concat
              (format "  %s = {%s},\n" name value)))))
 
-(defun bibtex-completion-add-PDF-attachment (keys)
+(defun bibtex-completion-add-pdf-attachment ()
+  ; this is basically a lowercase command alias for the function
+  ; ideally, that name should be deprecated in favor of this one
   "Attach the PDFs of the entries with the given KEYS where available."
   (interactive (list (bibtex-completion--read)))
+  (bibtex-completion-add-PDF-attachment))
+
+(defun bibtex-completion-add-PDF-attachment (keys)
+  "Attach the PDFs of the entries with the given KEYS where available."
   (dolist (key keys)
     (let ((pdf (bibtex-completion-find-pdf key bibtex-completion-find-additional-pdfs)))
       (if pdf

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1379,7 +1379,7 @@ Self-contained means that cross-referenced entries are merged."
              concat
              (format "  %s = {%s},\n" name value)))))
 
-(defun bibtex-completion-add-pdf-attachment ()
+(defun bibtex-completion-add-pdf-attachment (keys)
   ; this is basically a lowercase command alias for the function
   ; ideally, that name should be deprecated in favor of this one
   "Attach the PDFs of the entries with the given KEYS where available."

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -503,19 +503,23 @@ for string replacement."
   (bibtex-completion-init)
   (completing-read
    "BibTeX entries: "
-   (lambda (string pred action)
+   (lambda (string predicate action)
      (if (eq action 'metadata)
          '(metadata
+           ;; (annotation-function . bibtex-completion--annotation)
            (category . bibtex))
-       (complete-with-action action (bibtex-completion--get-candidates) string pred)))))
+       (complete-with-action action (bibtex-completion--get-candidates) string predicate)))))
 
 (defun bibtex-completion--get-candidates ()
   "Return all keys from bibtex-completion-candidates."
-  (mapcar
-   (lambda (cand)
-     (cons (bibtex-completion-format-entry cand (1- (frame-width)))
-           (cdr (assoc "=key=" cand))))
-   (bibtex-completion-candidates)))
+  (cl-loop
+   for candidate in (bibtex-completion-candidates)
+   collect
+   (cons
+    ;; Here use one string for display, and the other for search.
+    (propertize
+     (car candidate) 'display (bibtex-completion-format-entry candidate (1- (frame-width))))
+    (cdr (assoc "=key=" candidate)))))
 
 (defun bibtex-completion-candidates ()
   "Read the BibTeX files and return a list of conses, one for each entry.

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -72,7 +72,9 @@
     (define-key map (kbd "e") 'bibtex-completion-edit-notes)
     (define-key map (kbd "s") 'bibtex-completion-show-entry)
     (define-key map (kbd "l") 'bibtex-completion-add-pdf-to-library)
-    map))
+    map)
+  "Keymap for bibtex-completion commands"
+  )
 
 (defcustom bibtex-completion-bibliography nil
   "The BibTeX file or list of BibTeX files.

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -503,7 +503,11 @@ for string replacement."
   (bibtex-completion-init)
   (completing-read
    "BibTeX entries: "
-   (bibtex-completion--get-candidates)))
+   (lambda (string pred action)
+     (if (eq action 'metadata)
+         '(metadata
+           (category . bibtex))
+       (complete-with-action action (bibtex-completion--get-candidates) string pred)))))
 
 (defun bibtex-completion--get-candidates ()
   "Return all keys from bibtex-completion-candidates."


### PR DESCRIPTION
### Introduction

Over the last year, there has been a lot of activity on packages that are built around the emacs `completing-read` API. Designed for compatibility and modularity, but in collaboration, these tools together provide users flexibility and excellent functionality. 

This PR provides an alternative approach to (really just adapts code from) #355 as a means to offer bibtex-completion functionality to emacs vertically-oriented completion systems using `completing-read`, such as `icomplete-vertical` and `selectrum` (see #353).

The changes are minor, adding only about 70 very simple LOC. It follows @minad's advice to make the core functions interactive, using a new `bibtex-completion--read` function, which allows for configurable completion systems. 

By default, this function uses `completing-read`, which is already used in `bibtex-completion` in a few places.

But the intention is that one could use another function there, as the default function is bound to `bibtex-completion-read-backend` via `fset`.

So `ivy-bibtex` and `helm-bibtex` could, if there was value in this, instead use functions based on `ivy-read` and `helm-read` respectively (though this appears to be unnecessary, as they seem to work fine as is). One could even write a different `completing-read` function, if one wanted to modify the behavior locally, or in a separate package.

Also adds a keymap; `bibtex-completion-map`.

I do think this demonstrates how small a footprint this sort of change would introduce, while providing more flexibility for users and developers, but without impacting the packages that depend on it.

### Status

Everything seems to work correctly.

The basic `bibtex-completion--read` function works, and all of the action functions included in the keymap now use it. 

Here's a screenshot showing the most basic, default, installation, with `icomplete-vertical`:

![Screenshot from 2021-02-28 11-21-50](https://user-images.githubusercontent.com/1134/109425698-8b6bb580-79b7-11eb-8291-04527312c9f3.png)

With this setup, you only have access to the default command; there are no other actions/commands available.

Adding embark, however, adds that support, and so is strongly recommended. Binding the keymap to `embark-act` like so ...

``` elisp
(setf (alist-get 'bibtex embark-keymap-alist) 'bibtex-completion-map)
```

... will get you quick and easy access to additional actions, as well as the ability to snapshot sub collections and act on those as with `ivy-occur`. 

A full set of `completing-read` compatible packages to get, IMHO, the best experience using this includes the following:

- [selectrum](https://github.com/raxod502/selectrum) (narrowing and completion)
- [embark](https://github.com/oantolin/embark/) (actions)
- [consult](https://github.com/minad/consult) (commands)
- [prescient](https://github.com/raxod502/prescient.el) and [orderless](https://github.com/oantolin/orderless) (sorting and filtering)
- [marginalia](https://github.com/minad/marginalia) (minibuffer annotations)

Here is with the above installed and configured (though consult is not strictly necessary).

![Screenshot from 2021-03-01 16-20-49](https://user-images.githubusercontent.com/1134/109560655-22b13580-7aaa-11eb-953b-052a765d8996.png)


### Next Steps?

I could use help on the following (which will be valuable even if we go with #355 instead):

1. Reviewing the code.
2. Testing, in general, but also to see in particular that I am correct this doesn't impact `ivy-bibtex` and `helm-bibtex`
3. I'd also like to come up with a good example configuration, both with `embark` (looking into [embark-direct-action-mode, tablist](https://github.com/oantolin/embark/issues/166#issuecomment-784534410), and [hiding the general embark commands](https://github.com/tmalsburg/helm-bibtex/pull/355#issuecomment-784266618)) and without.
4. I'm wondering how to filter on items that have notes or pdfs . See #363.
5. Would we benefit from adding an annotation function (see [this comment](https://github.com/minad/marginalia/issues/58#issuecomment-782180044))? For now, I have a placeholder comment in the code. If yes, that might suggest a slightly different UI for completing-read; say putting some of the metadata in annotation, and having the candidate display itself narrower than the full frame width?

Finally, while I think out-of-scope for this PR:

6. Evaluating whether it could be helpful to have `helm-bibtex` and `ivy-bibtex` use an adapted `bibtex-completion--read`, and if so, implementing that. As I say above, the PR so far does not impact the functionality of the `helm-bibtex` and `ivy-bibtex` actions. The `bibtex-completion` commands also work, at least within `helm` (I haven't tested with`ivy`). 

### Testing

If you want to test this, but don't have the selectrum et al packages installed, a quick and simple option I recommend using `emacs -Q` is one of the selectrum [test scripts](https://github.com/raxod502/selectrum#contributor-guide), preferably the selectrum-prescient one.

All you need to do, then, is eval this code:

``` elisp
(require 'embark)
(load "~/Code/helm-bibtex/bibtex-completion.el")
(setf (alist-get 'bibtex embark-keymap-alist) 'bibtex-completion-map)
(setq bibtex-completion-bibliography "~/org/bib/academic.bib")
```
Upon running one of the commands, and narrowing the candidates, you can then run `embark-act` (in the test scripts, it is bound to `M-o`).

### Concerns

@tmalsburg has raised some reasonable concerns, which we can summarize as:

1. impact on code maintainability (what this PR is intending to test/demonstrate)
2. what to do about command names that weren't designed to be user facing?

https://github.com/tmalsburg/helm-bibtex/pull/355#issuecomment-775103918
https://github.com/tmalsburg/helm-bibtex/pull/355#issuecomment-775138438

Issue 1 I can't really assess, but is obviously the more serious issue. Hopefully this PR addresses this concern.

On 2, the function names are mostly OK, with two obvious issues: 

1. We have one function with "PDF" while all others are all lowercase. I addressed that with https://github.com/tmalsburg/helm-bibtex/pull/361/commits/a888ea50b78b3c789d94d0e04412be9c81657e47. 
2. `bibtex-completion-open-any`; I actually think it's fine, and more importantly, have a hard time coming up with something better (maybe omit the "any"?). But if we do, we could use the same solution as 1?

I suppose if we wanted to be aggressive, we could also think about:

- `bibtex-completion-open-any` ->  `bibtex-completion-open`
- `bibtex-completion-open-url-or-doi` ->  `bibtex-completion-open-link`
- `bibtex-completion-open-pdf` (per change noted above)

And for that matter consolidating around "insert" and "open" as the key action verbs.

Not sure, but it seems like something like `make-obsolete` could work?

``` elisp
;; we want new-name interactive, but `old-name` NOT interactive and deprecated
(defun old-name ()
  (message "old name"))

(defun new-name ()
  (interactive)
  (message "new name"))

(make-obsolete 'old-name 'new-name "2.0")

;; old-name function call still works
(old-name)
```

### Relation to #355

These would be functionally the same; just different command name prefixes.

@mtreca started #355, but this code is further-developed and feature-complete. I have merged the two code bases [here](https://github.com/bdarcus/bibtex-actions) as an experiment.

### Decisions

After working on this, I have concluded this should come down to a choice between two options:

1. merge this PR here
2. we develop a [separate project ](https://github.com/bdarcus/bibtex-actions/issues/12)(I don't see any benefit to anyone to host it here)

Each option is workable, I think, and each has trade-offs.

I suppose there's also a third option, which is merging this into an experimental branch for longer term consideration, and also doing the separate package now.