### PR TITLE
Add shorten-title function

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -904,7 +904,12 @@ governed by the variable `bibtex-completion-display-formats'."
                concat (car p))
     nil))
 
-
+(defun bibtex-completion-shorten-title (title)
+  "Return a main title sans subtitle from a TITLE."
+  (let* ((question-mark (string-match-p "?" title))
+         (short-title (car (split-string title "[:|?|.]"))))
+    (if question-mark (concat short-title "?") short-title)))
+
 (defun bibtex-completion-open-pdf (keys &optional fallback-action)
   "Open the PDFs associated with the marked entries using the function specified in `bibtex-completion-pdf-open-function'.
 If multiple PDFs are found for an entry, ask for the one to open


### PR DESCRIPTION
I was thinking this would be useful, so put together this simple PR.

This function splits titles with subtitles and extracts the main title.

It splits on the very common colon, of course, but also on periods and question marks.

Where there's a question mark, it adds back the punctuation.

Ideally this could be accessed from format-entry, but I'm not sure how that should work ATM.

OTOH, this could be a little fragile with some real world data.