### PR TITLE
Add =has-link= and bibtex-completion-link-symbol

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -183,6 +183,12 @@ This should be a single character."
   :group 'bibtex-completion
   :type 'string)
 
+(defcustom bibtex-completion-link-symbol "🔗"
+  "Symbol to indicate a DOI or URL link is available for a publication.
+This should be a single character."
+  :group 'bibtex-completion
+  :type 'string)
+
 (defcustom bibtex-completion-fallback-options
   '(("CrossRef                                  (biblio.el)"
      . (lambda (search-expression) (biblio-lookup #'biblio-crossref-backend search-expression)))

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -825,10 +825,14 @@ fields.  If FIELDS is empty, all fields are kept.  Also add a
 DO-NOT-FIND-PDF is non-nil, this function does not attempt to
 find a PDF file."
   (when entry ; entry may be nil, in which case just return nil
-    (let* ((fields (when fields (append fields (list "=type=" "=key=" "=has-pdf=" "=has-note="))))
+    (let* ((fields (when fields (append fields (list "=has-link" "=type=" "=key=" "=has-pdf=" "=has-note="))))
            ; Check for PDF:
            (entry (if (and (not do-not-find-pdf) (bibtex-completion-find-pdf entry))
                       (cons (cons "=has-pdf=" bibtex-completion-pdf-symbol) entry)
+                    entry))
+           ; Check for link:
+           (entry (if (or (assoc "doi" entry) (assoc "url" entry))
+                      (cons (cons "=has-link=" bibtex-completion-link-symbol) entry)
                     entry))
            (entry-key (cdr (assoc "=key=" entry)))
            ; Check for notes:

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1324,7 +1324,7 @@ Self-contained means that cross-referenced entries are merged."
              unless (member name
                             (append (-map (lambda (it) (if (symbolp it) (symbol-name it) it))
                                           bibtex-completion-no-export-fields)
-                             '("=type=" "=key=" "=has-pdf=" "=has-note=" "crossref")))
+                             '("=type=" "=key=" "=has-pdf=" "=has-note=" "=has-link=" "crossref")))
              concat
              (format "  %s = {%s},\n" name value)))))
 

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -831,7 +831,7 @@ find a PDF file."
                       (cons (cons "=has-pdf=" bibtex-completion-pdf-symbol) entry)
                     entry))
            ; Check for link:
-           (entry (if (or (assoc "doi" entry) (assoc "url" entry))
+           (entry (if (or (cdr (assoc "doi" entry)) (cdr (assoc "url" entry)))
                       (cons (cons "=has-link=" bibtex-completion-link-symbol) entry)
                     entry))
            (entry-key (cdr (assoc "=key=" entry)))


### PR DESCRIPTION
Another small PR.

This is for indicating the presence of a DOI or URL link associated
with the entry, and therefore items for which the relevant "open" 
functions will return a result.

Closes #363.

Status: AFAIK, this should work, but doesn't appear to ATM. See [line comment](https://github.com/tmalsburg/helm-bibtex/pull/366#discussion_r603252555) below.