### PR TITLE
Allow format-entry function to take optional template parameter

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -341,6 +341,14 @@ editor names."
   :group 'bibtex-completion
   :type '(alist :key-type symbol :value-type string))
 
+(defcustom bibtex-completion-display-formats-suffix nil
+  "Same format as display-formats template.
+When set, will render separate suffix string."
+  ; start with this; if needed, can always turn into a more general alt template
+  ; alist
+  :group 'bibtex-completion
+  :type '(alist :key-type symbol :value-type string))
+
 (defvar bibtex-completion-cross-referenced-entry-types
   '("proceedings" "mvproceedings" "book" "mvbook" "collection" "mvcollection")
   "The list of potentially cross-referenced entry types (in lowercase).
@@ -859,6 +867,7 @@ WIDTH is the width of the results list. The display format is
 governed by the variable `bibtex-completion-display-formats', or
 by ALT-DISPLAY-FORMATS if present."
   (let* ((format
+          ;; TODO: need to activate alt-display-formats somehow, bd
           (or (assoc-string (bibtex-completion-get-value "=type=" entry)
                             bibtex-completion-display-formats-internal
                             'case-fold)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -360,6 +360,11 @@ more types can slow down resolution for large biblioraphies.")
   "Stores `bibtex-completion-display-formats' together with the \"used width\" of each format string.
 This is set internally.")
 
+
+(defvar bibtex-completion-display-formats-suffix-internal nil
+  "Stores `bibtex-completion-display-suffix-formats' together with the \"used width\" of each format string.
+This is set internally.")
+
 (defvar bibtex-completion-cache nil
   "A cache storing the hash of the bibliography content and the corresponding list of entries, for each bibliography file, obtained when the bibliography was last parsed.
 When the current bibliography hash is identical to the cached
@@ -419,12 +424,13 @@ Also sets `bibtex-completion-display-formats-internal'."
             (user-error "Bibliography file %s could not be found" file)))
             (bibtex-completion-normalize-bibliography))
 
-  ;; Pre-calculate minimal widths needed by the format strings for
-  ;; various entry types:
   (setq bibtex-completion-display-formats-internal
         (bibtex-completion-process-display-format
-         bibtex-completion-display-formats)))
-        ; BD: turn variable into alist?
+         bibtex-completion-display-formats))
+
+  (setq bibtex-completion-display-formats-suffix-internal
+        (bibtex-completion-process-display-format
+         bibtex-completion-display-formats-suffix)))
 
 (defun bibtex-completion-process-display-format (formats)
   "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."
@@ -867,7 +873,8 @@ WIDTH is the width of the results list. The display format is
 governed by the variable `bibtex-completion-display-formats', or
 by ALT-DISPLAY-FORMATS if present."
   (let* ((format
-          ;; TODO: need to activate alt-display-formats somehow, bd
+          ;; TODO: need to activate
+          ;; bibtex-completion-display-formats-suffix-internal
           (or (assoc-string (bibtex-completion-get-value "=type=" entry)
                             bibtex-completion-display-formats-internal
                             'case-fold)

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -341,17 +341,6 @@ editor names."
   :group 'bibtex-completion
   :type '(alist :key-type symbol :value-type string))
 
-(defcustom bibtex-completion-display-formats-suffix
-    '((t . "${=has-pdf=:1}${=has-note=:1} ${=type=:7}"))
-  "For configuring a separate suffix display.
-This alist uses the same format as the display-formats template.  It can be
-used to render an affixation suffix or annotation, or simply a different
-face for this segment of the display."
-  ; start with this; if needed, can always turn into a more general alt template
-  ; alist
-  :group 'bibtex-completion
-  :type '(alist :key-type symbol :value-type string))
-
 (defvar bibtex-completion-cross-referenced-entry-types
   '("proceedings" "mvproceedings" "book" "mvbook" "collection" "mvcollection")
   "The list of potentially cross-referenced entry types (in lowercase).

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -873,8 +873,6 @@ WIDTH is the width of the results list. The display format is
 governed by the variable `bibtex-completion-display-formats', or
 by ALT-DISPLAY-FORMATS if present."
   (let* ((format
-          ;; TODO: need to activate
-          ;; bibtex-completion-display-formats-suffix-internal
           (if alt-display-formats
               (or (assoc-string (bibtex-completion-get-value "=type=" entry)
                                 bibtex-completion-display-formats-suffix-internal

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -875,16 +875,16 @@ find a PDF file."
 WIDTH is the width of the results list. The display format is
 governed by the variable `bibtex-completion-display-formats', or
 by ALT-DISPLAY-FORMATS if present."
-  (let* ((format
-          (if alt-display-formats
-              (or (assoc-string (bibtex-completion-get-value "=type=" entry)
-                                bibtex-completion-display-formats-suffix-internal
-                                'case-fold)
-                  (assoc t bibtex-completion-display-formats-suffix-internal))
-              (or (assoc-string (bibtex-completion-get-value "=type=" entry)
-                                bibtex-completion-display-formats-internal
-                                'case-fold)
-                  (assoc t bibtex-completion-display-formats-internal))))
+  (let* ((processed-format
+          (bibtex-completion-process-display-format
+           (or alt-display-formats bibtex-completion-display-formats)))
+         (format
+          (or
+           (assoc-string
+            (bibtex-completion-get-value "=type=" entry)
+            processed-format
+            'case-fold)
+           (assoc t processed-format)))
          (format-string (cadr format)))
     (s-format
      format-string

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -24,7 +24,7 @@
 
 ;; A BibTeX backend for completion frameworks
 
-;; There are currently two fronends: helm-bibtex and ivy-bibtex.
+;; There are currently two frontends: helm-bibtex and ivy-bibtex.
 ;;
 ;; See the github page for details:
 ;;

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -4,7 +4,7 @@
 ;;         Justin Burkett <justin@burkett.cc>
 ;; Maintainer: Titus von der Malsburg <malsburg@posteo.de>
 ;; URL: https://github.com/tmalsburg/helm-bibtex
-;; Version: 1.0.0
+;; Version: 1.1.0
 ;; Package-Requires: ((parsebib "1.0") (s "1.9.0") (dash "2.6.0") (f "0.16.2") (cl-lib "0.5") (biblio "0.2") (emacs "26.1"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -341,9 +341,12 @@ editor names."
   :group 'bibtex-completion
   :type '(alist :key-type symbol :value-type string))
 
-(defcustom bibtex-completion-display-formats-suffix nil
-  "Same format as display-formats template.
-When set, will render separate suffix string."
+(defcustom bibtex-completion-display-formats-suffix
+    '((t . "${=has-pdf=:1}${=has-note=:1} ${=type=:7}"))
+  "For configuring a separate suffix display.
+This alist uses the same format as the display-formats template.  It can be
+used to render an affixation suffix or annotation, or simply a different
+face for this segment of the display."
   ; start with this; if needed, can always turn into a more general alt template
   ; alist
   :group 'bibtex-completion

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -359,15 +359,6 @@ Only entries of these types are checked in order to resolve
 cross-references.  The default list is usually sufficient; adding
 more types can slow down resolution for large biblioraphies.")
 
-(defvar bibtex-completion-display-formats-internal nil
-  "Stores `bibtex-completion-display-formats' together with the \"used width\" of each format string.
-This is set internally.")
-
-
-(defvar bibtex-completion-display-formats-suffix-internal nil
-  "Stores `bibtex-completion-display-suffix-formats' together with the \"used width\" of each format string.
-This is set internally.")
-
 (defvar bibtex-completion-cache nil
   "A cache storing the hash of the bibliography content and the corresponding list of entries, for each bibliography file, obtained when the bibliography was last parsed.
 When the current bibliography hash is identical to the cached
@@ -404,8 +395,7 @@ their associated bibtex files."
   "List of file watches monitoring bibliography files for changes.")
 
 (defun bibtex-completion-init ()
-  "Check that the files and directories specified by the user actually exist.
-Also sets `bibtex-completion-display-formats-internal'."
+  "Check that the files and directories specified by the user actually exist."
 
   ;; Remove current watch-descriptors for bibliography files:
   (mapc (lambda (watch-descriptor)
@@ -425,15 +415,7 @@ Also sets `bibtex-completion-display-formats-internal'."
                 (setq bibtex-completion-file-watch-descriptors
                       (cons watch-descriptor bibtex-completion-file-watch-descriptors)))
             (user-error "Bibliography file %s could not be found" file)))
-            (bibtex-completion-normalize-bibliography))
-
-  (setq bibtex-completion-display-formats-internal
-        (bibtex-completion-process-display-format
-         bibtex-completion-display-formats))
-
-  (setq bibtex-completion-display-formats-suffix-internal
-        (bibtex-completion-process-display-format
-         bibtex-completion-display-formats-suffix)))
+            (bibtex-completion-normalize-bibliography)))
 
 (defun bibtex-completion-process-display-format (formats)
   "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -404,7 +404,7 @@ their associated bibtex files."
                 (setq bibtex-completion-file-watch-descriptors
                       (cons watch-descriptor bibtex-completion-file-watch-descriptors)))
             (user-error "Bibliography file %s could not be found" file)))
-            (bibtex-completion-normalize-bibliography)))
+        (bibtex-completion-normalize-bibliography)))
 
 (defun bibtex-completion-process-display-format (formats)
   "Pre-calculate minimal widths needed by the FORMATS strings for various entry types."

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -875,10 +875,15 @@ by ALT-DISPLAY-FORMATS if present."
   (let* ((format
           ;; TODO: need to activate
           ;; bibtex-completion-display-formats-suffix-internal
-          (or (assoc-string (bibtex-completion-get-value "=type=" entry)
-                            bibtex-completion-display-formats-internal
-                            'case-fold)
-              (assoc t bibtex-completion-display-formats-internal)))
+          (if alt-display-formats
+              (or (assoc-string (bibtex-completion-get-value "=type=" entry)
+                                bibtex-completion-display-formats-suffix-internal
+                                'case-fold)
+                  (assoc t bibtex-completion-display-formats-suffix-internal))
+              (or (assoc-string (bibtex-completion-get-value "=type=" entry)
+                                bibtex-completion-display-formats-internal
+                                'case-fold)
+                  (assoc t bibtex-completion-display-formats-internal))))
          (format-string (cadr format)))
     (s-format
      format-string


### PR DESCRIPTION
Add:

- optional template parameter to `bibtex-completion-format-entry` 
- a new ` bibtex-completion-process-display-format` function

Remove:

- the `internal` format var and init setq (so to decouple  `bibtex-completion-format-entry` from  `bibtex-completion-init`)

Also, bump version to 1.1, so other packages can specify this requirement (since they would break if they relied on this change, but loaded an earlier version).

-----

![Screenshot from 2021-03-26 11-04-25](https://user-images.githubusercontent.com/1134/112651865-3048a980-8e23-11eb-90cb-0c77d94dd5b6.png)

I want to do as title says, without breaking anything of course ...

``` elisp
(setq myfoo-formats-suffix "(${=key=:15}) ${=type=:12}:${tags:30}")
```

The obvious and clean solution is to modify `bibtex-completion-format-entry` to take an optional template parameter.

The screenshot above is with this PR (also shows has-note filtering as mentioned in #363). The "suffix" content on the right is using a different face from the main display, and that content generated by a different template.

This involves a net neutral change in LOC.