### PR TITLE
bibtex-find-key-from-file function

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -938,7 +938,7 @@ non-nil if notes exist for that entry.")
   "Return key associated with FILENAME-OR-BUFFER.
 
 FILENAME-OR-BUFFER can be a file name or a name of a buffer displaying the file."
-  (let (filename (or filename-or-buffer buffer-file-name))
+  (let ((filename (or filename-or-buffer buffer-file-name)))
     (when (bufferp filename)
       (setq filename (buffer-file-name filename-or-buffer)))
     (run-hook-with-args-until-success 'bibtex-completion-find-key-functions
@@ -946,11 +946,19 @@ FILENAME-OR-BUFFER can be a file name or a name of a buffer displaying the file.
 
 (defun bibtex-completion-find-key-from-note (filename)
   "Find a key associated with FILENAME."
-  (let ((key (file-name-base file-name)))
+  (let ((key (file-name-base filename)))
     (when (and (s-suffix-p bibtex-completion-notes-extension filename)
                (f-same? filename
                         (run-hook-with-args-until-success 'bibtex-completion-find-note-functions key)))
-      key)))
+      (list key))))
+
+(defun bibtex-completion-find-key-from-pdf (filename)
+  "Find a key associated with FILENAME."
+  (when (and (s-suffix-p bibtex-completion-pdf-extension filename)
+             (file-regular-p filename))
+    (mapcar #'(lambda (entry)
+                (bibtex-completion-get-value "=key=" entry))
+            (bibtex-completion-get-entry-with-string filename))))
 
 (defun bibtex-completion-prepare-entry (entry &optional fields do-not-find-pdf)
   "Prepare ENTRY for display.

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -972,7 +972,8 @@ The third case, `bibtex-completion-notes-path' is nil (the default),
 this function will return nil. 
 "
   (let (keys)
-    (cond ((and (f-file? bibtex-completion-notes-path)
+    (cond ((null bibtex-completion-notes-path) nil)
+          ((and (f-file? bibtex-completion-notes-path)
                 (s-suffix-p bibtex-completion-notes-extension filename)
                 (f-same? filename bibtex-completion-notes-path))
            (with-temp-buffer

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -954,11 +954,22 @@ FILENAME-OR-BUFFER can be a file name or a name of a buffer displaying the file.
 
 (defun bibtex-completion-find-key-from-pdf (filename)
   "Find a key associated with FILENAME."
-  (when (and (s-suffix-p bibtex-completion-pdf-extension filename)
-             (file-regular-p filename))
-    (mapcar #'(lambda (entry)
-                (bibtex-completion-get-value "=key=" entry))
-            (bibtex-completion-get-entry-with-string filename))))
+  (let (keys)
+    (when (string-match-p
+           (concat ".*" (mapconcat 'regexp-quote
+                                   (-flatten bibtex-completion-pdf-extension)
+                                   "\\|"))
+           filename)
+      (setq keys (mapcar #'(lambda (entry)
+                             (bibtex-completion-get-value "=key=" entry))
+                         (bibtex-completion-get-entry-with-string filename)))
+      (when (and bibtex-completion-library-path
+                 (not keys)
+                 (bibtex-completion-find-pdf-in-library
+                  (file-name-base filename)
+                  bibtex-completion-find-additional-pdfs))
+        (setq keys (list (file-name-base filename))))
+      keys)))
 
 (defun bibtex-completion-prepare-entry (entry &optional fields do-not-find-pdf)
   "Prepare ENTRY for display.

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -785,22 +785,26 @@ Returns nil if no PDF is found."
       (bibtex-completion-find-pdf-in-library key-or-entry find-additional)))
 
 (defun bibtex-completion-find-note-multiple-files (entry-key)
-  "Find note file associated with entry ENTRY-KEY in the default directory.
+  "Return note file associated with entry ENTRY-KEY in the default directory.
 The default directory is `bibtex-completion-notes-path'.  If the
 note file doesn’t exist, return nil."
-  (and bibtex-completion-notes-path
-       (f-directory? bibtex-completion-notes-path)
-       (f-file? (f-join bibtex-completion-notes-path
-                        (s-concat entry-key
-                                  bibtex-completion-notes-extension)))))
+  (when (and bibtex-completion-notes-path
+             (f-directory? bibtex-completion-notes-path)
+             (f-file? (f-join bibtex-completion-notes-path
+                              (s-concat entry-key
+                                        bibtex-completion-notes-extension))))
+    (f-join bibtex-completion-notes-path
+            (s-concat entry-key
+                      bibtex-completion-notes-extension))))
 
 (defun bibtex-completion-find-note-one-file (entry-key)
-  "Find notes associated with entry ENTRY-KEY in the single notes file.
+  "Return notes associated with entry ENTRY-KEY in the single notes file.
 The single notes file is the one specified in
 `bibtex-completion-notes-path'.  If no note exists, return nil."
-  (and bibtex-completion-notes-path
-       (f-file? bibtex-completion-notes-path)
-       (member entry-key bibtex-completion-cached-notes-keys)))
+  (when (and bibtex-completion-notes-path
+             (f-file? bibtex-completion-notes-path)
+             (member entry-key bibtex-completion-cached-notes-keys))
+    bibtex-completion-notes-path))
 
 ;; This defvar allows other packages like org-roam-bibtex to customize
 ;; the back-end for storing notes.


### PR DESCRIPTION
The initial idea is from #381. Their docstrings are quite extensive.
I've written four functions and one variable,
the function `find-key-from-file` delegates finding key to every function in the new variable `find-key-functions` each takes one argument called FILENAME.

The `find-key-functions` includes
1. `find-key-from-note`, a function that returns a list of key associated with FILENAME and `bibtex-completion-notes-path` depending on its value.

2. `find-key-from-pdf`, thats use another new function `get-entry-with-string` (See description in #381. TLDR; list every entry with STRING in its fields.) to return a list of entries with FILENAME in its fields then extract the `"=key="` field from each entry in the list or just return the BibTex part of FILENAME in a list.