### PR TITLE
fix: support commas in file name tmalsburg/helm-bibtex#371

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -705,37 +705,43 @@ does not exist, or if `bibtex-completion-pdf-field' is nil."
        ((not value) nil)         ; Field not defined.
        ((f-file? value) (list value))   ; A bare full path was found.
        ((-any 'f-file? (--map (f-join it (f-filename value)) (-flatten bibtex-completion-library-path))) (-filter 'f-file? (--map (f-join it (f-filename value)) (-flatten bibtex-completion-library-path))))
-       (t                               ; Zotero/Mendeley/JabRef/Calibre format:
-        (let ((value (replace-regexp-in-string "\\([^\\]\\)[;,]" "\\1\^^" value)))
-          (cl-loop  ; Looping over the files:
-           for record in (s-split "\^^" value)
-                                        ; Replace unescaped colons by field separator:
-           for record = (replace-regexp-in-string "\\([^\\]\\|^\\):" "\\1\^_" record)
-                                        ; Unescape stuff:
-           for record = (replace-regexp-in-string "\\\\\\(.\\)" "\\1" record)
-                                        ; Now we can safely split:
-           for record = (s-split "\^_" record)
-           for file-name = (nth 0 record)
-           for path = (or (nth 1 record) "")
-           for paths = (if (s-match "^[A-Z]:" path)
-                           (list path)                 ; Absolute Windows path
-                                        ; Something else:
-                         (append
-                          (list
-                           path
-                           file-name
-                           (f-join (f-root) path) ; Mendeley #105
-                           (f-join (f-root) path file-name)) ; Mendeley #105
-                          (--map (f-join it path)
-                                 (-flatten bibtex-completion-library-path)) ; Jabref #100
-                          (--map (f-join it path file-name)
-                                 (-flatten bibtex-completion-library-path)))) ; Jabref #100
-           for result = (-first (lambda (path)
-                                  (if (and (not (s-blank-str? path))
-                                           (f-exists? path))
-                                      path nil)) paths)
-           if result collect result)))))))
+       (t
+        (cl-loop  ; Looping over the files:
+         for record in (bibtex-completion-get-file-record value)
+                                      ; Replace unescaped colons by field separator:
+         for record = (replace-regexp-in-string "\\([^\\]\\|^\\):" "\\1\^_" record)
+                                      ; Unescape stuff:
+         for record = (replace-regexp-in-string "\\\\\\(.\\)" "\\1" record)
+                                      ; Now we can safely split:
+         for record = (s-split "\^_" record)
+         for file-name = (nth 0 record)
+         for path = (or (nth 1 record) "")
+         for paths = (if (s-match "^[A-Z]:" path)
+                         (list path)                 ; Absolute Windows path
+                                      ; Something else:
+                       (append
+                        (list
+                         path
+                         file-name
+                         (f-join (f-root) path) ; Mendeley #105
+                         (f-join (f-root) path file-name)) ; Mendeley #105
+                        (--map (f-join it path)
+                               (-flatten bibtex-completion-library-path)) ; Jabref #100
+                        (--map (f-join it path file-name)
+                               (-flatten bibtex-completion-library-path)))) ; Jabref #100
+         for result = (-first (lambda (path)
+                                (if (and (not (s-blank-str? path))
+                                         (f-exists? path))
+                                    path nil)) paths)
+         if result collect result))))))
 
+(defun bibtex-completion-get-file-record (pdf-field-value)
+  "Return the splitted list of record from PDF-FIELD-VALUE"
+  ; Zotero/Mendeley/JabRef format:
+  (setq pdf-field-value (replace-regexp-in-string "\\([^\\]\\);" "\\1\^^" pdf-field-value))
+  ; Calibre format:
+  (setq pdf-field-value (replace-regexp-in-string "\\(\.[A-Za-z0-9]+:[A-Za-z0-9]+\\)," "\\1\^^" pdf-field-value))
+  (s-split "\^^" pdf-field-value))
 
 (defun bibtex-completion-find-pdf-in-library (key-or-entry &optional find-additional)
   "Searches the directories in `bibtex-completion-library-path' for a PDF whose name is composed of the BibTeX key plus `bibtex-completion-pdf-extension'.


### PR DESCRIPTION
1. Support comma splitted bib, like calibe
2. Support comma in file name