### PR TITLE
Update ivy-bibtex.el

### DIFF
--- a/ivy-bibtex.el
+++ b/ivy-bibtex.el
@@ -105,7 +105,7 @@
   (let* ((width (- (frame-width) 2))
 	 (idx (get-text-property 1 'idx candidate))
 	 (entry (cdr (nth idx (ivy-state-collection ivy-last)))))
-    (s-concat (if (s-starts-with-p ivy-mark-prefix candidate) ivy-mark-prefix " ")
+    (s-concat (if (s-starts-with-p ivy-mark-prefix candidate) ivy-mark-prefix "")
 	      (bibtex-completion-format-entry entry width))))
 
 (defmacro ivy-bibtex-ivify-action (action name)


### PR DESCRIPTION
There is a bug in `ivy-bibtex-display-transformer` that causes marking candidates to stop working. The issue is the space that gets inserted. It should be an empty space.