### PR TITLE
do not reverse (and unreverse) the files list

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -486,7 +486,7 @@ The first element of these conses is a string containing authors,
 editors, title, year, type, and key of the entry.  This string
 is used for matching.  The second element is the entry (only the
 fields listed above) as an alist."
-  (let ((files (nreverse (bibtex-completion-normalize-bibliography 'bibtex)))
+  (let ((files (bibtex-completion-normalize-bibliography 'bibtex))
         (ht-strings (make-hash-table :test #'equal))
         reparsed-files)
 
@@ -567,10 +567,9 @@ fields listed above) as an alist."
 
     ;; Finally return the list of candidates:
     (message "Done (re)loading bibliography.")
-    (nreverse
-     (cl-loop
-      for file in files
-      append (cddr (assoc file bibtex-completion-cache))))))
+    (cl-loop
+     for file in files
+     append (cddr (assoc file bibtex-completion-cache)))))
 
 (defun bibtex-completion-resolve-crossrefs (files reparsed-files)
   "Expand all entries with fields from cross-referenced entries in FILES, assuming that only those files in REPARSED-FILES were reparsed whereas the other files in FILES were up-to-date."


### PR DESCRIPTION
BibTeX requires files in a particular order (dependencies first) and so does this library (also
dependencies first). However, the double reversal makes the latter incompatible with the former.

Consider a bibliographical database spread across two `bib` files, e.g. 

```bibtex
% file-1.bib

@string{eurocryptname =         "EUROCRYPT"}
@string{eurocryptpub =          springer}
@string{eurocrypt17-2 =         "EC17-2"}
@string{eurocrypt17name2 =      eurocryptname # "~2017, Part~II"}
@string{eurocrypt17ed =         "Jean-S{\'{e}}bastien Coron and Jesper Buus Nielsen"}
@string{eurocrypt17addr =       "Paris, France"}
@string{eurocrypt17month =      apr # "~30~--~" # may # "~4,"}

% file-2.bib

@Proceedings{EC17-2,
  title =        eurocrypt17name2,
  editor =       eurocrypt17ed,
  booktitle =    eurocrypt17name2,
  volume =       eurocrypt17vol2,
  address =      eurocrypt17addr,
  month =        eurocrypt17month,
  publisher =    eurocryptpub,
  series =       mylncs,
  year =         2017,
  key =          eurocrypt17key2,
}

@InProceedings{EC:Albrecht17,
  author =       "Martin R. Albrecht",
  title =        "On Dual Lattice Attacks Against Small-Secret {LWE} and Parameter Choices in {HElib} and {SEAL}",
  pages =        "103--129",
  doi =          "10.1007/978-3-319-56614-6_4",
  crossref =     eurocrypt17-2,
}
```

Both BibTeX and this library require `file-1.bib` to come before `file-2.bib` but the double reversal means this library processed files in the opposite order of BibTeX.