### PR TITLE
Add function bibtex-completion-get-key-org-cite

### DIFF
--- a/README.org
+++ b/README.org
@@ -727,6 +727,19 @@ Helm-bibtex and ivy-bibtex display entries in the order in which they appear in 
             :filter-return 'reverse)
 #+END_SRC
 
+** Use ~helm-bibtex~ or ~ivy-bibtex~ as an ~org-cite-follow-processor~
+
+Invoking ~helm-bibtex~ or ~ivy-bibtex~ when point is on an [[https://orgmode.org/manual/Citation-handling.html][org-mode citation]] will automatically select that key. However, the default ~org-open-at-point~ on a org citation will take you to the corresponding bibliography entry. The following code will change this behavior to instead open ~helm-bibtex~ when following an org citation by entering ~RET~ or clicking on it:
+
+#+BEGIN_SRC elisp
+(org-cite-register-processor 'my-bibtex-org-cite-follow
+  :follow (lambda (_ _) (helm-bibtex)))
+
+(setq org-cite-follow-processor 'my-bibtex-org-cite-follow)
+#+END_SRC
+
+Note in the case of an org citations with multiple keys, the above code will not preselect any entry when the ~[cite:~ portion is selected.
+
 * Troubleshooting
 
 ** Helm-bibtex doesn’t show any entries

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1609,10 +1609,20 @@ find the key of the BibTeX entry at point in an Org-mode buffer."
            (> (length key) 0)
            key))))
 
+(defun bibtex-completion-get-key-org-cite ()
+  "Return the org-cite key at point, nil otherwise.
+This function can be used by `bibtex-completion-key-at-point' to
+find the org-cite key at point in an Org-mode buffer."
+  (when (eq major-mode 'org-mode)
+    (let ((el (org-element-context)))
+      (when (eq (car el) 'citation-reference)
+        (plist-get (cadr el) :key)))))
+
 (defvar bibtex-completion-key-at-point-functions
   (list #'bibtex-completion-get-key-bibtex
         #'bibtex-completion-get-key-latex
-        #'bibtex-completion-get-key-org-bibtex)
+        #'bibtex-completion-get-key-org-bibtex
+        #'bibtex-completion-get-key-org-cite)
   "List of functions to use to find the BibTeX key.
 The functions should take no argument and return the BibTeX
 key.  Stops as soon as a function returns something.


### PR DESCRIPTION
Adding support for the new org cite syntax. This then allows one to trivially use `helm-bibtex` or `ivy-bibtex` as an `org-cite-follow-processor' by setting

```
(org-cite-register-processor 'ivy-bibtex-org-cite-follow
  :follow (lambda (_ _) (ivy-bibtex)))

(setq org-cite-follow-processor 'ivy-bibtex-org-cite-follow)
```

While this doesn't handle follow when point is on `cite:` as there may be multiple keys, it's good enough for me.