### PR TITLE
add a separate follow processor for helm

### DIFF
--- a/README.org
+++ b/README.org
@@ -137,6 +137,16 @@ The names of these files consist of the BibTeX key plus a user-defined suffix (~
 
 At this point most people will be ready to go.  Skip to [[#usage][Usage]] below to see how to use helm-bibtex and ivy-bibtex.
 
+** Follow processor for helm
+
+Invoking ~helm-bibtex~ or ~ivy-bibtex~ when point is on an [[https://orgmode.org/manual/Citation-handling.html][org-mode citation]] will automatically select that key. However, the default ~org-open-at-point~ on a org citation will take you to the corresponding bibliography entry. The following code will change this behavior to instead open ~helm-bibtex-follow~ when following an org citation by entering ~RET~ or clicking on it:
+
+#+BEGIN_SRC elisp
+(setq org-cite-follow-processor 'helm-bibtex-org-cite-follow)
+#+END_SRC
+
+Note in the case of an org citation with multiple keys, the above code will not preselect any entry when the ~[cite:~ portion is selected. See [[https://github.com/tmalsburg/helm-bibtex#use-ivy-bibtex-as-an-org-cite-follow-processor][here]] for the ivy alternative.
+
 * Advanced configuration
 ** Customize layout of search results
 
@@ -728,18 +738,16 @@ Helm-bibtex and ivy-bibtex display entries in the order in which they appear in 
             :filter-return 'reverse)
 #+END_SRC
 
-** Use ~helm-bibtex~ or ~ivy-bibtex~ as an ~org-cite-follow-processor~
+** Use ~ivy-bibtex~ as an ~org-cite-follow-processor~
 
-Invoking ~helm-bibtex~ or ~ivy-bibtex~ when point is on an [[https://orgmode.org/manual/Citation-handling.html][org-mode citation]] will automatically select that key. However, the default ~org-open-at-point~ on a org citation will take you to the corresponding bibliography entry. The following code will change this behavior to instead open ~helm-bibtex~ when following an org citation by entering ~RET~ or clicking on it:
+As mentioned [[https://github.com/tmalsburg/helm-bibtex#follow-processor-for-helm][here]], the default ~org-open-at-point~ on a org citation will take you to the corresponding bibliography entry. The following code will change this behavior to instead open ~ivy-bibtex~ when following an org citation by entering ~RET~ or clicking on it:
 
 #+BEGIN_SRC elisp
-(org-cite-register-processor 'my-bibtex-org-cite-follow
-  :follow (lambda (_ _) (helm-bibtex)))
+(org-cite-register-processor 'my-ivy-bibtex-org-cite-follow
+  :follow (lambda (_ _) (ivy-bibtex)))
 
-(setq org-cite-follow-processor 'my-bibtex-org-cite-follow)
+(setq org-cite-follow-processor 'my-ivy-bibtex-org-cite-follow)
 #+END_SRC
-
-Note in the case of an org citation with multiple keys, the above code will not preselect any entry when the ~[cite:~ portion is selected.
 
 * Troubleshooting
 

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -284,8 +284,11 @@ reread."
 When nil, the window will split below.")
 
 ;;;###autoload
-(defun helm-bibtex-follow (citation &optional args)
-  (let* ((key (plist-get (cadr citation) :key))
+(defun helm-bibtex-follow (&optional citation args)
+  (interactive)
+  (let* ((key (if citation
+                  (plist-get (cadr citation) :key)
+                (bibtex-completion-key-at-point)))
          (item-info
           (format "%s\t\t%s"
                   (bibtex-completion-apa-get-value
@@ -297,7 +300,7 @@ When nil, the window will split below.")
             :candidates helm-bibtex-follow-actions-alist
             :action (lambda (x) (funcall x (list key))))
           :full-frame helm-bibtex-follow-full-frame
-          :buffer "*helm bibtex*")))
+          :buffer "*helm bibtex follow*")))
 
 
 (org-cite-register-processor 'helm-bibtex-org-cite-follow

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -300,6 +300,9 @@ When nil, the window will split below.")
           :buffer "*helm bibtex*")))
 
 
+(org-cite-register-processor 'helm-bibtex-org-cite-follow
+  :follow 'helm-bibtex-follow)
+
 
 (provide 'helm-bibtex)
 

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -279,9 +279,11 @@ reread."
     ("Add PDF to library"         . bibtex-completion-add-pdf-to-library)))
 
 
-(defvar helm-bibtex-follow-full-frame nil
+(defcustom helm-bibtex-follow-full-frame nil
   "Non-nil means open ‘helm-bibtex-follow’ using the entire window.
-When nil, the window will split below.")
+When nil, the window will split below."
+  :group 'bibtex-completion
+  :type 'boolean)
 
 ;;;###autoload
 (defun helm-bibtex-follow (&optional citation args)

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -269,6 +269,38 @@ reread."
                  candidates))))
     (helm-bibtex)))
 
+;; Helm-bibtex follow processor:
+
+(defvar helm-bibtex-follow-actions-alist
+  '(("Open PDF, URL or DOI"       . bibtex-completion-open-pdf)
+    ("Open URL or DOI in browser" . bibtex-completion-open-url-or-doi)
+    ("Edit notes"                 . bibtex-completion-edit-notes)
+    ("Show entry"                 . bibtex-completion-show-entry)
+    ("Add PDF to library"         . bibtex-completion-add-pdf-to-library)))
+
+
+(defvar helm-bibtex-follow-full-frame nil
+  "Non-nil means open ‘helm-bibtex-follow’ using the entire window.
+When nil, the window will split below.")
+
+;;;###autoload
+(defun helm-bibtex-follow (citation &optional args)
+  (let* ((key (plist-get (cadr citation) :key))
+         (item-info
+          (format "%s\t\t%s"
+                  (bibtex-completion-apa-get-value
+                   "title" (bibtex-completion-get-entry key))
+                  (bibtex-completion-apa-get-value
+                   "author" (bibtex-completion-get-entry key)))))
+    (helm :sources
+          (helm-build-sync-source item-info
+            :candidates helm-bibtex-follow-actions-alist
+            :action (lambda (x) (funcall x (list key))))
+          :full-frame helm-bibtex-follow-full-frame
+          :buffer "*helm bibtex*")))
+
+
+
 (provide 'helm-bibtex)
 
 ;; Local Variables:


### PR DESCRIPTION
Thanks for your great package!

Having helm-bibtex open as the follow processor is not ideal, since to take an action, we need to press tab and then not all actions are meaningful when point is on a citation. The PR adds a separate follow processor and two new variables, `helm-bibtex-follow-actions-alist` and `helm-bibtex-follow-full-frame`, to customize it. To use this processor, this should be added to the init file:
```elisp
(org-cite-register-processor 'my-bibtex-org-cite-follow
  :follow 'helm-bibtex-follow)

(setq org-cite-follow-processor 'my-bibtex-org-cite-follow)
```