### PR TITLE
Improve formatting of APA-style citations when biblatex files are used

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1185,6 +1185,9 @@ string if FIELD is not present in ENTRY and DEFAULT is nil."
      ("editor-abbrev"
       (when-let ((value (bibtex-completion-get-value "editor" entry)))
         (bibtex-completion-apa-format-editors-abbrev value)))
+     ((or "journal" "journaltitle")
+      (or (bibtex-completion-get-value "journal" entry)
+          (bibtex-completion-get-value "journaltitle" entry)))
      (_
       ;; Real fields:
       (let ((value (bibtex-completion-get-value field entry)))


### PR DESCRIPTION
Currently, only the field `journal` is pulled from when formatting APA-style citations.  Users of biblatex may store journal name information in `journaltitle` instead.  This allows for either name to be used in templates, and gets the data from whichever field is filled, `journal` preferred.