### PR TITLE
enable evaluation of date field if year is not defined

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -1191,7 +1191,7 @@ string if FIELD is not present in ENTRY and DEFAULT is nil."
      (_
       ;; Real fields:
       (let ((value (bibtex-completion-get-value field entry)))
-        (if value
+	(if (or value (and field (string= field "year")))
             (pcase field
               ;; https://owl.english.purdue.edu/owl/resource/560/06/
               ("author" (bibtex-completion-apa-format-authors value))


### PR DESCRIPTION
Without this addition to the if clause, in cases where the `year` field is missing, the line where `date` substitutes `year` will never be evaluated. This means that the year is missing when inserting the reference into an org-file, but also in org-roam-ui, for example (e.g. "Author (). Title").