### PR TITLE
Add option to enable parsebib's `replace-tex` option

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -200,6 +200,11 @@ This should be a single character."
   :group 'bibtex-completion
   :type 'string)
 
+(defcustom bibtex-completion-replace-tex nil
+  "Make use of parsebib's ability to parse TeX and replace it by unicode characters."
+  :group 'bibtex-completion
+  :type 'boolean)
+
 (defcustom bibtex-completion-fallback-options
   '(("CrossRef                                  (biblio.el)"
      . (lambda (search-expression) (biblio-lookup #'biblio-crossref-backend search-expression)))
@@ -686,7 +691,7 @@ If HT-STRINGS is provided it is assumed to be a hash table."
    for entry-type = (parsebib-find-next-item)
    while entry-type
    if (not (member-ignore-case entry-type '("preamble" "string" "comment")))
-   collect (let* ((entry (parsebib-read-entry nil ht-strings))
+   collect (let* ((entry (parsebib-read-entry nil ht-strings bibtex-completion-replace-tex))
                   (fields (append
                            (list (if (assoc-string "author" entry 'case-fold)
                                      "author"

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -5,7 +5,7 @@
 ;; Maintainer: Titus von der Malsburg <malsburg@posteo.de>
 ;; URL: https://github.com/tmalsburg/helm-bibtex
 ;; Version: 1.0.0
-;; Package-Requires: ((parsebib "6.0") (s "1.9.0") (dash "2.6.0") (f "0.16.2") (cl-lib "0.5") (biblio "0.2") (emacs "26.1"))
+;; Package-Requires: ((parsebib "6.2") (s "1.9.0") (dash "2.6.0") (f "0.16.2") (cl-lib "0.5") (biblio "0.2") (emacs "26.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -685,8 +685,7 @@ Also do some preprocessing of the entries.
 If HT-STRINGS is provided it is assumed to be a hash table."
   (goto-char (point-min))
 
-  (cl-letf (((symbol-function 'parsebib--convert-tex-italics) (lambda (str) str))
-            ((symbol-function 'parsebib--convert-tex-bold) (lambda (str) str)))
+  (let ((parsebib-TeX-cleanup-target 'plain))
     (cl-loop
      with fields = (append '("title" "crossref")
                            (-map (lambda (it) (if (symbolp it) (symbol-name it) it))

--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -684,7 +684,6 @@ Also do some preprocessing of the entries.
 
 If HT-STRINGS is provided it is assumed to be a hash table."
   (goto-char (point-min))
-
   (let ((parsebib-TeX-cleanup-target 'plain))
     (cl-loop
      with fields = (append '("title" "crossref")

--- a/helm-bibtex.el
+++ b/helm-bibtex.el
@@ -174,12 +174,18 @@ comes out in the right buffer."
 
 ;; Helm sources:
 
+(defcustom helm-bibtex-ignore-diacritics nil
+  "Ignore diacritics when searching."
+  :group 'bibtex-completion
+  :type 'boolean)
+
 (defvar helm-source-bibtex
   (helm-build-sync-source "BibTeX entries"
     :header-name (lambda (name)
                    (format "%s%s: " name (if helm-bibtex-local-bib " (local)" "")))
     :candidates 'helm-bibtex-candidates
     :filtered-candidate-transformer 'helm-bibtex-candidates-formatter
+    :diacritics helm-bibtex-ignore-diacritics
     :action (helm-make-actions
              "Open PDF, URL or DOI"       'helm-bibtex-open-any
              "Open URL or DOI in browser" 'helm-bibtex-open-url-or-doi


### PR DESCRIPTION
This PR 
- adds `bibtex-completion-replace-tex` which is passed to `parsebib-read-entry` for `replace-tex`
- adds `helm-bibtex-ignore-diacritics` which is passed to `:diacritics` in `helm-source-bibtex`

Both are `nil` by default, preserving the current behaviour of this package.