### PR TITLE
Support AUCTeX's (new) LaTeX-mode

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -128,6 +128,7 @@ This should be a single character."
 (defcustom bibtex-completion-format-citation-functions
   '((org-mode      . bibtex-completion-format-citation-ebib)
     (latex-mode    . bibtex-completion-format-citation-cite)
+    (LaTeX-mode    . bibtex-completion-format-citation-cite)    
     (markdown-mode . bibtex-completion-format-citation-pandoc-citeproc)
     (python-mode   . bibtex-completion-format-citation-sphinxcontrib-bibtex)
     (rst-mode      . bibtex-completion-format-citation-sphinxcontrib-bibtex)


### PR DESCRIPTION
AUCTeX (14.0.1+) has renamed latex-mode -> LaTeX-mode. As a result, inserting citations in buffers that are in `LaTeX-mode` result in `bibtex-completion-insert-citation` falling back on the default `bibtex-completion-format-citation-default`, which just inserts the naked key without wrapping it in a `\cite` command (or similar).

A simple hack is to explicitly support both `latex-mode` *and* `LaTeX-mode`