### PR TITLE
Avoid infinite loop when parsing a .bib file.

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -496,7 +496,8 @@ for string replacement."
                    if (string= (downcase entry-type) "string")
                    collect (let ((entry (parsebib-read-string ht)))
                              (puthash (car entry) (cdr entry) ht)
-                             entry))))
+                             entry)
+                   else do (forward-line 1))))
     (-filter (lambda (x) x) strings)))
 
 (defun bibtex-completion-update-strings-ht (ht strings)
@@ -684,7 +685,7 @@ If HT-STRINGS is provided it is assumed to be a hash table."
                                bibtex-completion-additional-search-fields))
    for entry-type = (parsebib-find-next-item)
    while entry-type
-   unless (member-ignore-case entry-type '("preamble" "string" "comment"))
+   if (not (member-ignore-case entry-type '("preamble" "string" "comment")))
    collect (let* ((entry (parsebib-read-entry nil ht-strings))
                   (fields (append
                            (list (if (assoc-string "author" entry 'case-fold)
@@ -696,7 +697,8 @@ If HT-STRINGS is provided it is assumed to be a hash table."
                            fields)))
              (-map (lambda (it)
                      (cons (downcase (car it)) (cdr it)))
-                   (bibtex-completion-prepare-entry entry fields)))))
+                   (bibtex-completion-prepare-entry entry fields)))
+   else do (forward-line 1)))
 
 (defun bibtex-completion-get-entry (entry-key)
   "Given a BibTeX key this function scans all bibliographies listed in `bibtex-completion-bibliography' and returns an alist of the record with that key.


### PR DESCRIPTION
In parsebib.el 4.7 / 5.0, the function parsebib-find-next-item leaves point after the @-sign when it finds an item. In parsebib.el 6.0, it leaves point *before* the @-sign. Therefore, the caller must advance point if the item is not read, otherwise parsebib-find-next-item will keep finding the same item.

This fixes the problems reported in https://github.com/tmalsburg/helm-bibtex/issues/452 and https://github.com/jkitchin/scimax/issues/510.