### PR TITLE
(bibtex-completion-get-entry1): Position point correctly.

### DIFF
--- a/bibtex-completion.el
+++ b/bibtex-completion.el
@@ -717,7 +717,8 @@ Fields from crossreferenced entries are appended to the requested entry."
                                      "\\)[[:space:]]*[\(\{][[:space:]]*"
                                      (regexp-quote entry-key) "[[:space:]]*,")
                              nil t)
-          (let ((entry-type (match-string 1)))
+          (progn
+            (goto-char (match-beginning 0))
             (reverse (bibtex-completion-prepare-entry
                       (parsebib-read-entry nil bibtex-completion-string-hash-table) nil do-not-find-pdf)))
         (progn


### PR DESCRIPTION
Since parsebib 6.0, `parsebib-read-entry` expects point to be before the entry to be read. 

Also remove the let-binding for `entry-type`, since it's no longer needed.